### PR TITLE
Fix PSGallery publishing with dotnet nuget push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -181,19 +181,11 @@ jobs:
         Get-Content $HashPath
         echo "::endgroup::"
     
-    - name: Upload package artifacts
+    - name: Upload artifacts
       uses: actions/upload-artifact@v4
       with:
         name: AwakeCoding.PSRemoting-${{ needs.preflight.outputs.package-version }}
         path: package/
-        if-no-files-found: error
-        retention-days: 90
-        
-    - name: Upload module folder
-      uses: actions/upload-artifact@v4
-      with:
-        name: AwakeCoding.PSRemoting-Module-${{ needs.preflight.outputs.package-version }}
-        path: AwakeCoding.PSRemoting/
         if-no-files-found: error
         retention-days: 90
 
@@ -203,22 +195,17 @@ jobs:
     runs-on: ubuntu-22.04
     
     steps:
-    - name: Download package artifacts
+    - name: Download artifacts
       uses: actions/download-artifact@v4
       with:
         name: AwakeCoding.PSRemoting-${{ needs.preflight.outputs.package-version }}
         path: package/
         
-    - name: Download module folder
-      uses: actions/download-artifact@v4
-      with:
-        name: AwakeCoding.PSRemoting-Module-${{ needs.preflight.outputs.package-version }}
-        path: AwakeCoding.PSRemoting/
-        
     - name: Publish to PowerShell Gallery
       shell: pwsh
       env:
         PSGALLERY_API_KEY: ${{ secrets.PSGALLERY_API_KEY }}
+      working-directory: package
       run: |
         $SkipPSGallery = [System.Boolean]::Parse('${{ needs.preflight.outputs.skip-psgallery }}')
         $DryRun = [System.Boolean]::Parse('${{ needs.preflight.outputs.dry-run }}')
@@ -228,21 +215,30 @@ jobs:
           exit 0
         }
         
-        if ($DryRun) {
-          Write-Host "Dry Run: Skipping PowerShell Gallery publishing"
-          Write-Host "Would publish module from: AwakeCoding.PSRemoting/"
-          Get-ChildItem AwakeCoding.PSRemoting/ | Select-Object Name | Format-Table
-          exit 0
-        }
+        # Find the .nupkg file
+        $nupkgFile = Get-ChildItem -Filter "*.nupkg" | Select-Object -First 1
         
-        if ([string]::IsNullOrEmpty($env:PSGALLERY_API_KEY)) {
-          Write-Error "PSGALLERY_API_KEY secret is not set"
+        if (-not $nupkgFile) {
+          Write-Error "No .nupkg file found in artifacts"
           exit 1
         }
         
-        Write-Host "Publishing module from: AwakeCoding.PSRemoting/"
-        Publish-Module -Path AwakeCoding.PSRemoting -NuGetApiKey $env:PSGALLERY_API_KEY -Repository PSGallery -Verbose
-        Write-Host "Module published successfully"
+        $PushArgs = @(
+          'nuget', 'push', $nupkgFile.Name,
+          '--api-key', $env:PSGALLERY_API_KEY,
+          '--source', 'https://www.powershellgallery.com/',
+          '--skip-duplicate', '--no-symbols'
+        )
+        
+        Write-Host "dotnet $($PushArgs -Join ' ')"
+        
+        if ($DryRun) {
+          Write-Host "Dry Run: Skipping PowerShell Gallery publishing"
+          Write-Host "Would publish: $($nupkgFile.Name)"
+        } else {
+          & dotnet $PushArgs
+          Write-Host "Module published successfully"
+        }
         
     - name: Create GitHub release
       shell: pwsh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -181,11 +181,19 @@ jobs:
         Get-Content $HashPath
         echo "::endgroup::"
     
-    - name: Upload artifacts
+    - name: Upload package artifacts
       uses: actions/upload-artifact@v4
       with:
         name: AwakeCoding.PSRemoting-${{ needs.preflight.outputs.package-version }}
         path: package/
+        if-no-files-found: error
+        retention-days: 90
+        
+    - name: Upload module folder
+      uses: actions/upload-artifact@v4
+      with:
+        name: AwakeCoding.PSRemoting-Module-${{ needs.preflight.outputs.package-version }}
+        path: AwakeCoding.PSRemoting/
         if-no-files-found: error
         retention-days: 90
 
@@ -195,17 +203,22 @@ jobs:
     runs-on: ubuntu-22.04
     
     steps:
-    - name: Download artifacts
+    - name: Download package artifacts
       uses: actions/download-artifact@v4
       with:
         name: AwakeCoding.PSRemoting-${{ needs.preflight.outputs.package-version }}
         path: package/
         
+    - name: Download module folder
+      uses: actions/download-artifact@v4
+      with:
+        name: AwakeCoding.PSRemoting-Module-${{ needs.preflight.outputs.package-version }}
+        path: AwakeCoding.PSRemoting/
+        
     - name: Publish to PowerShell Gallery
       shell: pwsh
       env:
         PSGALLERY_API_KEY: ${{ secrets.PSGALLERY_API_KEY }}
-      working-directory: package
       run: |
         $SkipPSGallery = [System.Boolean]::Parse('${{ needs.preflight.outputs.skip-psgallery }}')
         $DryRun = [System.Boolean]::Parse('${{ needs.preflight.outputs.dry-run }}')
@@ -217,7 +230,8 @@ jobs:
         
         if ($DryRun) {
           Write-Host "Dry Run: Skipping PowerShell Gallery publishing"
-          Write-Host "Would publish: $(Get-ChildItem -Filter '*.nupkg' | Select-Object -First 1 -ExpandProperty Name)"
+          Write-Host "Would publish module from: AwakeCoding.PSRemoting/"
+          Get-ChildItem AwakeCoding.PSRemoting/ | Select-Object Name | Format-Table
           exit 0
         }
         
@@ -226,16 +240,8 @@ jobs:
           exit 1
         }
         
-        # Find the .nupkg file
-        $nupkgPath = Get-ChildItem -Filter "*.nupkg" | Select-Object -First 1 -ExpandProperty FullName
-        
-        if (-not $nupkgPath) {
-          Write-Error "No .nupkg file found in artifacts"
-          exit 1
-        }
-        
-        Write-Host "Publishing package: $(Split-Path $nupkgPath -Leaf)"
-        Publish-PSResource -Path $nupkgPath -ApiKey $env:PSGALLERY_API_KEY -Repository PSGallery
+        Write-Host "Publishing module from: AwakeCoding.PSRemoting/"
+        Publish-Module -Path AwakeCoding.PSRemoting -NuGetApiKey $env:PSGALLERY_API_KEY -Repository PSGallery -Verbose
         Write-Host "Module published successfully"
         
     - name: Create GitHub release


### PR DESCRIPTION
This PR fixes the PSGallery publishing issue that was failing with Publish-PSResource.

## Problem
The release workflow was failing with:
`
Publish-PSResource: Cannot retrieve the dynamic parameters for the cmdlet. Loading repository store failed: 
Could not find a part of the path '/home/runner/.local/share/PSResourceGet/PSResourceRepository.xml'.
`

## Solution
Switch from PowerShell cmdlets to dotnet nuget push for publishing, which:
- Uses the dotnet CLI (always available on GitHub runners)
- Doesn't require PSResourceGet repository configuration
- Publishes the already-created .nupkg file directly
- Includes --skip-duplicate flag to handle re-runs gracefully
- Includes --no-symbols flag (symbol packages not needed for PowerShell modules)

## Changes
- Removed module folder upload/download (no longer needed)
- Use dotnet nuget push instead of Publish-Module/Publish-PSResource
- Improved dry-run output to show exact command that would be executed