### PR TITLE
Add custom WinRM transport with bundled SSPI auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AwakeCoding PSRemoting Extensions
 
-PowerShell remoting without network transport - create local PowerShell sessions via subprocess stdio, and host remoting endpoints via TCP, WebSocket, or Named Pipes.
+PowerShell remoting without WinRM listener dependencies - create PowerShell sessions via subprocess stdio or custom transports, and host remoting endpoints via TCP, WebSocket, Named Pipe, or WinRM.
 
 ## Installation
 
@@ -11,7 +11,8 @@ Install-Module AwakeCoding.PSRemoting
 ## Features
 
 - **Client Sessions**: Create PSSession objects connected to local PowerShell subprocesses
-- **Server Infrastructure**: Host PowerShell remoting endpoints on TCP, WebSocket, or Named Pipe transports
+- **Custom WinRM Transport**: Connect to PowerShell over WSMan/WinRM using the module's own HTTP/SOAP transport
+- **Server Infrastructure**: Host PowerShell remoting endpoints on TCP, WebSocket, Named Pipe, or WinRM transports
 - **Process Connection**: Connect to existing PowerShell processes via named pipes
 - **Cross-Platform**: Works on Windows, Linux, and macOS
 
@@ -53,6 +54,9 @@ Enter-PSHostSession -ProcessId 12345
 
 # SSH connection
 Enter-PSHostSession -SSHTransport -HostName remote-server
+
+# WinRM connection
+Enter-PSHostSession -ComputerName remote-server -Authentication Negotiate
 ```
 
 ## Creating Sessions Without Entering
@@ -153,6 +157,66 @@ WSManStackVersion              3.0
 ```
 
 This can be useful to have a script running using the latest PowerShell that can drive executions in multiple older versions of PowerShell through local PSRemoting.
+
+## WinRM Transport - Remote PowerShell Over WSMan
+
+The `New-PSHostSession` cmdlet also supports a transport-owned WinRM implementation built on `HttpClient` and WSMan SOAP requests. This does not depend on PowerShell's built-in WSMan client stack, which makes it useful when you want more control over authentication and wire behavior.
+
+### Basic WinRM Connection
+
+```powershell
+# HTTP / default WSMan endpoint (prompts for credentials by default)
+$session = New-PSHostSession -ComputerName 'server01'
+
+# HTTPS / port 5986
+$session = New-PSHostSession -ComputerName 'server01' -UseSSL
+
+# Specify an explicit port and enter the session
+$session = New-PSHostSession -ComputerName 'server01' -Port 5985
+$session | Enter-PSSession
+
+# Explicit WinRM endpoint URI
+$session = New-PSHostSession -ConnectionUri 'http://server01:5985/wsman'
+```
+
+### Authentication and Configuration
+
+```powershell
+# Prompt for credentials and use Negotiate (default)
+$session = New-PSHostSession -ComputerName 'server01'
+
+# Supply a PSCredential explicitly
+$cred = Get-Credential -UserName 'Administrator'
+$session = New-PSHostSession -ComputerName 'server01' -Credential $cred
+
+# Supply the user name separately and prompt only for the password
+$session = New-PSHostSession -ComputerName 'server01' -UserName 'Administrator'
+
+# Supply the user name and password separately
+$password = Read-Host 'Password' -AsSecureString
+$session = New-PSHostSession -ComputerName 'server01' `
+    -UserName 'Administrator' `
+    -Password $password
+
+# On Windows only, opt into the current logon token
+$session = New-PSHostSession -ComputerName 'server01' -UseImplicitCredential
+
+# Basic auth against a lab endpoint
+$session = New-PSHostSession -ComputerName 'server01' `
+    -Authentication Basic `
+    -Credential $cred
+
+# Custom configuration endpoint and application path
+$session = New-PSHostSession -ComputerName 'server01' `
+    -ConfigurationName 'PowerShell.7' `
+    -ApplicationName '/wsman'
+```
+
+Negotiate and Kerberos use a transport-owned SSPI layer. The module prefers the packaged `Devolutions.Sspi` runtime on every platform, and on Windows it automatically falls back to native Windows SSPI if that bundled runtime cannot be loaded.
+
+WinRM now expects explicit credentials by default. If you omit `-Credential`, the cmdlet prompts for credentials. You can also provide `-UserName` on its own to prefill the prompt, or pair `-UserName` with `-Password` to avoid constructing a `PSCredential` yourself. To use the current Windows logon token instead, opt in with `-UseImplicitCredential`. This implicit mode is Windows-only and is not valid with `-Authentication Basic`.
+
+Use `-ComputerName` or `-ConnectionUri` for WinRM. Use `-SSHTransport -HostName` for SSH. This matches PowerShell's built-in transport split while still reserving plain `-HostName -Port` for the custom TCP transport in this module.
 
 ## SSH Transport - Remote PowerShell Over SSH
 
@@ -291,6 +355,24 @@ $server = Start-PSHostServer -TransportType NamedPipe
 $server = Start-PSHostServer -TransportType NamedPipe -PipeName 'MyCustomPipe'
 ```
 
+### Start-PSHostServer - WinRM Transport
+
+Start a lightweight WinRM/WSMan listener backed by a PowerShell subprocess:
+
+```powershell
+# Start a WinRM listener on the default /wsman path
+$server = Start-PSHostServer -TransportType WinRM -Port 5985
+
+# Start on a custom path
+$server = Start-PSHostServer -TransportType WinRM -Port 5986 -WinRMPath '/custom-wsman'
+
+# Require Basic authentication with an explicit credential
+$cred = Get-Credential -UserName 'lab\administrator'
+$server = Start-PSHostServer -TransportType WinRM -Port 5987 -Credential $cred
+```
+
+You can connect to that listener with `New-PSHostSession -ComputerName ...` or `-ConnectionUri ...`, or by using any WSMan client that can target the hosted endpoint path.
+
 ### Managing Servers
 
 ```powershell
@@ -299,6 +381,9 @@ Get-PSHostServer
 
 # Filter by transport type
 Get-PSHostServer -TransportType TCP
+
+# List WinRM listeners
+Get-PSHostServer -TransportType WinRM
 
 # Stop server by name
 Stop-PSHostServer -Name 'PSHostTcpServer8080'

--- a/build.ps1
+++ b/build.ps1
@@ -1,6 +1,13 @@
 
 dotnet restore .\src\AwakeCoding.PSRemoting.PowerShell.csproj
+if ($LASTEXITCODE -ne 0) {
+    exit $LASTEXITCODE
+}
+
 dotnet build -c Release -f net8.0 --no-restore
+if ($LASTEXITCODE -ne 0) {
+    exit $LASTEXITCODE
+}
 
 $OutputPath = "$PSScriptRoot\src\bin\Release\net8.0"
 $ModulePath = "$PSScriptRoot\AwakeCoding.PSRemoting"

--- a/build.ps1
+++ b/build.ps1
@@ -1,5 +1,6 @@
 
-dotnet build -c Release -f net8.0
+dotnet restore .\src\AwakeCoding.PSRemoting.PowerShell.csproj
+dotnet build -c Release -f net8.0 --no-restore
 
 $OutputPath = "$PSScriptRoot\src\bin\Release\net8.0"
 $ModulePath = "$PSScriptRoot\AwakeCoding.PSRemoting"
@@ -29,6 +30,17 @@ foreach ($dll in $Dependencies) {
     } else {
         Write-Warning "Dependency not found: $dll"
     }
+}
+
+$RuntimesPath = Join-Path $OutputPath 'runtimes'
+if (Test-Path $RuntimesPath) {
+    $ModuleRuntimesPath = Join-Path $ModulePath 'runtimes'
+    if (Test-Path $ModuleRuntimesPath) {
+        Remove-Item $ModuleRuntimesPath -Recurse -Force
+    }
+
+    Copy-Item $RuntimesPath $ModulePath -Recurse -Force
+    Write-Host "Copied: runtimes\"
 }
 
 Write-Host "`nModule files copied to: $ModulePath" -ForegroundColor Green

--- a/src/AwakeCoding.PSRemoting.PowerShell.csproj
+++ b/src/AwakeCoding.PSRemoting.PowerShell.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Devolutions.Sspi" Version="2026.3.27" />
+    <PackageReference Include="Devolutions.Sspi" Version="2026.3.27" ExcludeAssets="build;buildTransitive" />
     <PackageReference Include="System.Management.Automation" Version="7.4.*" PrivateAssets="all" />
     <PackageReference Include="System.Net.Http.WinHttpHandler" Version="*" />
     <PackageReference Include="Tmds.Ssh" Version="0.11.0" />

--- a/src/AwakeCoding.PSRemoting.PowerShell.csproj
+++ b/src/AwakeCoding.PSRemoting.PowerShell.csproj
@@ -15,7 +15,9 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Devolutions.Sspi" Version="2026.3.27" />
     <PackageReference Include="System.Management.Automation" Version="7.4.*" PrivateAssets="all" />
+    <PackageReference Include="System.Net.Http.WinHttpHandler" Version="*" />
     <PackageReference Include="Tmds.Ssh" Version="0.11.0" />
     <Reference Include="System.Management.Automation">
       <HintPath>.\Ref\System.Management.Automation.dll</HintPath>

--- a/src/PSHostServerCommands.cs
+++ b/src/PSHostServerCommands.cs
@@ -8,7 +8,7 @@ namespace AwakeCoding.PSRemoting.PowerShell
     /// Start-PSHostServer cmdlet - Starts a PowerShell remoting server with specified transport
     /// </summary>
     [Cmdlet(VerbsLifecycle.Start, "PSHostServer")]
-    [OutputType(typeof(PSHostTcpServer), typeof(PSHostWebSocketServer), typeof(PSHostNamedPipeServer))]
+    [OutputType(typeof(PSHostTcpServer), typeof(PSHostWebSocketServer), typeof(PSHostNamedPipeServer), typeof(PSHostWinRMServer))]
     public sealed class StartPSHostServerCommand : PSCmdlet
     {
         // Common parameters
@@ -50,6 +50,15 @@ namespace AwakeCoding.PSRemoting.PowerShell
         [ValidateNotNullOrEmpty()]
         public string? PipeName { get; set; }
 
+        // WinRM-specific parameters
+        [Parameter()]
+        [ValidateNotNullOrEmpty()]
+        public string WinRMPath { get; set; } = "/wsman";
+
+        [Parameter()]
+        [Credential()]
+        public PSCredential? Credential { get; set; }
+
         protected override void BeginProcessing()
         {
             PSHostServerBase server;
@@ -68,6 +77,10 @@ namespace AwakeCoding.PSRemoting.PowerShell
 
                     case PSHostTransportType.NamedPipe:
                         server = CreateNamedPipeServer();
+                        break;
+
+                    case PSHostTransportType.WinRM:
+                        server = CreateWinRMServer();
                         break;
 
                     default:
@@ -230,6 +243,37 @@ namespace AwakeCoding.PSRemoting.PowerShell
                 maxConnections: MaxConnections,
                 drainTimeout: DrainTimeout);
         }
+
+        private PSHostWinRMServer CreateWinRMServer()
+        {
+            if (!Port.HasValue)
+                throw new ArgumentException("Port parameter is required for WinRM transport");
+
+            int portValue = Port.Value;
+
+            if (portValue == 0)
+                throw new ArgumentException("WinRM server requires a specific port (cannot be 0)");
+
+            if (string.IsNullOrWhiteSpace(Name))
+                Name = $"PSHostWinRMServer{portValue}";
+
+            var existingServer = PSHostServerBase.GetServer(Name);
+            if (existingServer != null)
+                throw new InvalidOperationException($"Server with name '{Name}' already exists");
+
+            var serverOnPort = PSHostServerBase.GetServerByPort(portValue);
+            if (serverOnPort != null)
+                throw new InvalidOperationException($"Server '{serverOnPort.Name}' is already listening on port {portValue}");
+
+            return new PSHostWinRMServer(
+                name: Name,
+                port: portValue,
+                listenAddress: ListenAddress,
+                path: WinRMPath,
+                maxConnections: MaxConnections,
+                drainTimeout: DrainTimeout,
+                requiredCredential: Credential);
+        }
     }
 
     /// <summary>
@@ -330,7 +374,7 @@ namespace AwakeCoding.PSRemoting.PowerShell
     /// Get-PSHostServer cmdlet - Retrieves PowerShell remoting servers
     /// </summary>
     [Cmdlet(VerbsCommon.Get, "PSHostServer", DefaultParameterSetName = "All")]
-    [OutputType(typeof(PSHostTcpServer), typeof(PSHostWebSocketServer), typeof(PSHostNamedPipeServer))]
+    [OutputType(typeof(PSHostTcpServer), typeof(PSHostWebSocketServer), typeof(PSHostNamedPipeServer), typeof(PSHostWinRMServer))]
     public sealed class GetPSHostServerCommand : PSCmdlet
     {
         [Parameter(ParameterSetName = "ByName", Position = 0, Mandatory = true, ValueFromPipeline = true, ValueFromPipelineByPropertyName = true)]
@@ -408,6 +452,7 @@ namespace AwakeCoding.PSRemoting.PowerShell
                                 PSHostTransportType.TCP => allServers.OfType<PSHostTcpServer>(),
                                 PSHostTransportType.WebSocket => allServers.OfType<PSHostWebSocketServer>(),
                                 PSHostTransportType.NamedPipe => allServers.OfType<PSHostNamedPipeServer>(),
+                                PSHostTransportType.WinRM => allServers.OfType<PSHostWinRMServer>(),
                                 _ => allServers
                             };
                         }

--- a/src/PSHostSessionCommandBase.cs
+++ b/src/PSHostSessionCommandBase.cs
@@ -5,6 +5,8 @@ using System.Management.Automation;
 using System.Management.Automation.Internal;
 using System.Management.Automation.Remoting;
 using System.Management.Automation.Runspaces;
+using System.Runtime.InteropServices;
+using System.Security;
 using System.Threading;
 
 namespace AwakeCoding.PSRemoting.PowerShell
@@ -20,6 +22,8 @@ namespace AwakeCoding.PSRemoting.PowerShell
         protected const string NamedPipeParameterSet = "NamedPipe";
         protected const string ProcessIdParameterSet = "ProcessId";
         protected const string SSHParameterSet = "SSH";
+        protected const string WinRMComputerNameParameterSet = "WinRMComputerName";
+        protected const string WinRMConnectionUriParameterSet = "WinRMConnectionUri";
 
         protected const int DefaultOpenTimeoutMs = 30000;
         protected const int DefaultReadinessTimeoutMs = 5000;
@@ -29,6 +33,7 @@ namespace AwakeCoding.PSRemoting.PowerShell
         protected RunspaceConnectionInfo? _connectionInfo;
         protected Runspace? _runspace;
         protected ManualResetEvent? _openAsync;
+        protected DateTime _runspaceOpenStart;
 
         #region Subprocess Parameters
 
@@ -53,14 +58,14 @@ namespace AwakeCoding.PSRemoting.PowerShell
         [Parameter(ParameterSetName = TcpParameterSet, Mandatory = true)]
         [Parameter(ParameterSetName = SSHParameterSet, Mandatory = true, Position = 0)]
         [ValidateNotNullOrEmpty()]
-        [Alias("ComputerName")]
         public string? HostName { get; set; }
 
         /// <summary>
-        /// Port number. Required for TCP, optional for SSH (default 22).
+        /// Port number. Required for TCP, optional for SSH (default 22) and WinRM (default 5985/5986).
         /// </summary>
         [Parameter(ParameterSetName = TcpParameterSet, Mandatory = true)]
         [Parameter(ParameterSetName = SSHParameterSet)]
+        [Parameter(ParameterSetName = WinRMComputerNameParameterSet)]
         [ValidateRange(1, 65535)]
         public int Port { get; set; }
 
@@ -76,9 +81,11 @@ namespace AwakeCoding.PSRemoting.PowerShell
         public SwitchParameter SSHTransport { get; set; }
 
         /// <summary>
-        /// SSH user name (can include domain, e.g., "Administrator@domain")
+        /// SSH or WinRM user name (can include domain, e.g., "Administrator@domain").
         /// </summary>
         [Parameter(ParameterSetName = SSHParameterSet)]
+        [Parameter(ParameterSetName = WinRMComputerNameParameterSet)]
+        [Parameter(ParameterSetName = WinRMConnectionUriParameterSet)]
         [ValidateNotNullOrEmpty()]
         public string? UserName { get; set; }
 
@@ -122,6 +129,8 @@ namespace AwakeCoding.PSRemoting.PowerShell
         /// Credential for SSH password authentication
         /// </summary>
         [Parameter(ParameterSetName = SSHParameterSet)]
+        [Parameter(ParameterSetName = WinRMComputerNameParameterSet)]
+        [Parameter(ParameterSetName = WinRMConnectionUriParameterSet)]
         [Credential()]
         public PSCredential? Credential { get; set; }
 
@@ -130,6 +139,75 @@ namespace AwakeCoding.PSRemoting.PowerShell
         /// </summary>
         [Parameter(ParameterSetName = SSHParameterSet)]
         public SwitchParameter SkipHostKeyCheck { get; set; }
+
+        #endregion
+
+        #region WinRM Parameters
+
+        /// <summary>
+        /// Target computer name for WinRM connections.
+        /// </summary>
+        [Parameter(ParameterSetName = WinRMComputerNameParameterSet, Mandatory = true, Position = 0)]
+        [ValidateNotNullOrEmpty()]
+        public string? ComputerName { get; set; }
+
+        /// <summary>
+        /// WinRM endpoint URI (for example, http://server01:5985/wsman).
+        /// </summary>
+        [Parameter(ParameterSetName = WinRMConnectionUriParameterSet, Mandatory = true, Position = 0)]
+        [ValidateNotNullOrEmpty()]
+        public Uri? ConnectionUri { get; set; }
+
+        /// <summary>
+        /// Use HTTPS for WinRM (port 5986 by default).
+        /// </summary>
+        [Parameter(ParameterSetName = WinRMComputerNameParameterSet)]
+        public SwitchParameter UseSSL { get; set; }
+
+        /// <summary>
+        /// Authentication mechanism for WinRM (Default = Negotiate).
+        /// </summary>
+        [Parameter(ParameterSetName = WinRMComputerNameParameterSet)]
+        [Parameter(ParameterSetName = WinRMConnectionUriParameterSet)]
+        public WinRMAuthenticationMechanism Authentication { get; set; } = WinRMAuthenticationMechanism.Negotiate;
+
+        /// <summary>
+        /// WinRM password to combine with -UserName when you do not want to construct a PSCredential yourself.
+        /// </summary>
+        [Parameter(ParameterSetName = WinRMComputerNameParameterSet)]
+        [Parameter(ParameterSetName = WinRMConnectionUriParameterSet)]
+        [ValidateNotNull()]
+        public SecureString? Password { get; set; }
+
+        /// <summary>
+        /// Use the current Windows logon token for WinRM Negotiate/Kerberos instead of prompting for explicit credentials.
+        /// </summary>
+        [Parameter(ParameterSetName = WinRMComputerNameParameterSet)]
+        [Parameter(ParameterSetName = WinRMConnectionUriParameterSet)]
+        public SwitchParameter UseImplicitCredential { get; set; }
+
+        /// <summary>
+        /// Allow HTTP redirects for WinRM connections.
+        /// </summary>
+        [Parameter(ParameterSetName = WinRMComputerNameParameterSet)]
+        [Parameter(ParameterSetName = WinRMConnectionUriParameterSet)]
+        public SwitchParameter AllowRedirection { get; set; }
+
+        /// <summary>
+        /// WSMan application name (default "/wsman").
+        /// </summary>
+        [Parameter(ParameterSetName = WinRMComputerNameParameterSet)]
+        [ValidateNotNullOrEmpty()]
+        public string ApplicationName { get; set; } = "/wsman";
+
+        /// <summary>
+        /// PowerShell session configuration name (default "Microsoft.PowerShell").
+        /// Use "PowerShell.7" to connect to a PS7 endpoint.
+        /// </summary>
+        [Parameter(ParameterSetName = WinRMComputerNameParameterSet)]
+        [Parameter(ParameterSetName = WinRMConnectionUriParameterSet)]
+        [ValidateNotNullOrEmpty()]
+        public string ConfigurationName { get; set; } = WsManXml.DefaultConfigurationName;
 
         #endregion
 
@@ -212,6 +290,12 @@ namespace AwakeCoding.PSRemoting.PowerShell
                     TransportName ??= "SSH";
                     break;
 
+                case WinRMComputerNameParameterSet:
+                case WinRMConnectionUriParameterSet:
+                    _connectionInfo = CreateWinRMConnectionInfo();
+                    TransportName ??= "WinRM";
+                    break;
+
                 case SubprocessParameterSet:
                 default:
                     _connectionInfo = CreateSubprocessConnectionInfo();
@@ -227,18 +311,20 @@ namespace AwakeCoding.PSRemoting.PowerShell
                 name: RunspaceName);
 
             _openAsync = new ManualResetEvent(false);
+            _runspaceOpenStart = DateTime.UtcNow;
             _runspace.StateChanged += HandleRunspaceStateChanged;
 
             try
             {
                 _runspace.OpenAsync();
 
-                // Wait for runspace to reach Opened/Closed/Broken state with timeout
-                if (!_openAsync.WaitOne(OpenTimeout))
+                // Wait for runspace to reach Opened/Closed/Broken state with timeout.
+                int effectiveTimeout = Math.Max(OpenTimeout, _connectionInfo.OpenTimeout);
+                if (!_openAsync.WaitOne(effectiveTimeout))
                 {
                     // Timeout - clean up and throw
                     try { _runspace.Dispose(); } catch { }
-                    throw new TimeoutException($"Runspace open timed out after {OpenTimeout}ms");
+                    throw new TimeoutException($"Runspace open timed out after {effectiveTimeout}ms");
                 }
 
                 // Check if runspace opened successfully
@@ -364,7 +450,7 @@ namespace AwakeCoding.PSRemoting.PowerShell
 
         private RunspaceConnectionInfo CreateSSHConnectionInfo()
         {
-            // Use the new SSHClientInfo with thread-based transport for interactive console passthrough
+// Use the new SSHClientInfo with thread-based transport for interactive console passthrough
             var connectionInfo = new SSHClientInfo(
                 computerName: HostName!,
                 userName: UserName,
@@ -393,6 +479,138 @@ namespace AwakeCoding.PSRemoting.PowerShell
             return connectionInfo;
         }
 
+        private RunspaceConnectionInfo CreateWinRMConnectionInfo()
+        {
+            string computerName;
+            int port;
+            bool useSsl;
+            string applicationName;
+
+            if (ParameterSetName == WinRMConnectionUriParameterSet)
+            {
+                if (ConnectionUri == null)
+                {
+                    throw new ArgumentException("ConnectionUri is required for WinRM URI connections");
+                }
+
+                if (!ConnectionUri.Scheme.Equals("http", StringComparison.OrdinalIgnoreCase)
+                    && !ConnectionUri.Scheme.Equals("https", StringComparison.OrdinalIgnoreCase))
+                {
+                    throw new ArgumentException($"Invalid WinRM URI scheme: {ConnectionUri.Scheme}. Expected 'http' or 'https'.");
+                }
+
+                applicationName = string.IsNullOrEmpty(ConnectionUri.AbsolutePath)
+                    ? "/wsman"
+                    : ConnectionUri.AbsolutePath;
+                computerName = ConnectionUri.Host;
+                port = ConnectionUri.IsDefaultPort ? 0 : ConnectionUri.Port;
+                useSsl = ConnectionUri.Scheme.Equals("https", StringComparison.OrdinalIgnoreCase);
+            }
+            else
+            {
+                computerName = ComputerName!;
+                port = Port > 0 ? Port : (UseSSL ? 5986 : 5985);
+                useSsl = UseSSL;
+                applicationName = ApplicationName;
+            }
+
+            (PSCredential? credential, bool useImplicitCredential) = ResolveWinRMCredential(computerName);
+
+            return new WinRMClientInfo(computerName)
+            {
+                Port = port,
+                UseSSL = useSsl,
+                Authentication = Authentication,
+                Credential = credential,
+                UseImplicitCredential = useImplicitCredential,
+                ApplicationName = applicationName,
+                ConfigurationName = ConfigurationName,
+                AllowRedirection = AllowRedirection,
+                OpenTimeout = OpenTimeout
+            };
+        }
+
+        private (PSCredential? Credential, bool UseImplicitCredential) ResolveWinRMCredential(string targetName)
+        {
+            bool hasCredential = Credential != null;
+            bool hasUserName = !string.IsNullOrWhiteSpace(UserName);
+            bool hasPassword = Password != null;
+
+            if (UseImplicitCredential)
+            {
+                if (Authentication == WinRMAuthenticationMechanism.Basic)
+                {
+                    throw new InvalidOperationException("WinRM implicit credentials cannot be used with Basic authentication.");
+                }
+
+                if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                {
+                    throw new PlatformNotSupportedException("WinRM implicit credentials are only supported on Windows. Supply -Credential or -UserName with -Password instead.");
+                }
+
+                if (hasCredential || hasUserName || hasPassword)
+                {
+                    throw new InvalidOperationException("Do not combine -UseImplicitCredential with -Credential, -UserName, or -Password.");
+                }
+
+                return (null, true);
+            }
+
+            if (hasCredential)
+            {
+                if (hasUserName || hasPassword)
+                {
+                    throw new InvalidOperationException("Do not combine -Credential with -UserName or -Password for WinRM connections.");
+                }
+
+                return (Credential, false);
+            }
+
+            if (hasPassword && !hasUserName)
+            {
+                throw new InvalidOperationException("Specify -UserName when using -Password for WinRM connections.");
+            }
+
+            if (hasUserName && hasPassword)
+            {
+                return (new PSCredential(UserName!, Password!), false);
+            }
+
+            return (PromptForWinRMCredential(targetName), false);
+        }
+
+        private PSCredential PromptForWinRMCredential(string targetName)
+        {
+            if (Host?.UI == null)
+            {
+                throw new InvalidOperationException(
+                    "WinRM connections require explicit credentials by default. Supply -Credential or -UserName with -Password, or use -UseImplicitCredential on Windows.");
+            }
+
+            try
+            {
+                PSCredential? credential = Host.UI.PromptForCredential(
+                    caption: "WinRM Authentication",
+                    message: $"Enter credentials for the WinRM connection to '{targetName}'.",
+                    userName: UserName ?? string.Empty,
+                    targetName: targetName);
+
+                return credential ?? throw new InvalidOperationException("The WinRM credential prompt was cancelled.");
+            }
+            catch (System.Management.Automation.Host.HostException ex)
+            {
+                throw new InvalidOperationException(
+                    "WinRM connections require explicit credentials by default, but the current host cannot prompt for them. Supply -Credential or -UserName with -Password, or use -UseImplicitCredential on Windows.",
+                    ex);
+            }
+            catch (NotImplementedException ex)
+            {
+                throw new InvalidOperationException(
+                    "WinRM connections require explicit credentials by default, but the current host cannot prompt for them. Supply -Credential or -UserName with -Password, or use -UseImplicitCredential on Windows.",
+                    ex);
+            }
+        }
+
         protected override void StopProcessing()
         {
             ReleaseWait();
@@ -400,7 +618,9 @@ namespace AwakeCoding.PSRemoting.PowerShell
 
         protected void HandleRunspaceStateChanged(object? source, RunspaceStateEventArgs stateEventArgs)
         {
-            switch (stateEventArgs.RunspaceStateInfo.State)
+            var state = stateEventArgs.RunspaceStateInfo.State;
+            WinRMTrace.WriteLine($"[WINRM-DBG +{(DateTime.UtcNow - _runspaceOpenStart).TotalMilliseconds:F0}ms] RUNSPACE STATE: {state}  Reason={stateEventArgs.RunspaceStateInfo.Reason?.Message}");
+            switch (state)
             {
                 case RunspaceState.Opened:
                 case RunspaceState.Closed:

--- a/src/PSHostTransportType.cs
+++ b/src/PSHostTransportType.cs
@@ -18,6 +18,11 @@ namespace AwakeCoding.PSRemoting.PowerShell
         /// <summary>
         /// Named Pipe transport
         /// </summary>
-        NamedPipe
+        NamedPipe,
+
+        /// <summary>
+        /// WinRM (WSMan over HTTP/HTTPS) transport
+        /// </summary>
+        WinRM
     }
 }

--- a/src/PSHostWinRMClientTransport.cs
+++ b/src/PSHostWinRMClientTransport.cs
@@ -1,0 +1,2114 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Management.Automation;
+using System.Management.Automation.Internal;
+using System.Management.Automation.Remoting;
+using System.Management.Automation.Remoting.Client;
+using System.Management.Automation.Runspaces;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+
+namespace AwakeCoding.PSRemoting.PowerShell
+{
+    /// <summary>
+    /// Authentication mechanism for WinRM connections
+    /// </summary>
+    public enum WinRMAuthenticationMechanism
+    {
+        /// <summary>Negotiate (NTLM or Kerberos)</summary>
+        Default,
+        /// <summary>HTTP Basic authentication (username + password in Base64)</summary>
+        Basic,
+        /// <summary>Negotiate authentication (NTLM or Kerberos via SSPI/GSSAPI)</summary>
+        Negotiate,
+        /// <summary>Kerberos-only authentication</summary>
+        Kerberos
+    }
+
+    internal static class WinRMTrace
+    {
+        public static void WriteLine(string message)
+        {
+        }
+    }
+
+    /// <summary>
+    /// Connection info for WinRM-based PowerShell remoting connections.
+    /// Uses HttpClient to implement the WSMan/SOAP protocol over HTTP/HTTPS.
+    /// </summary>
+    public sealed class WinRMClientInfo : RunspaceConnectionInfo
+    {
+        private const int DefaultHttpPort = 5985;
+        private const int DefaultHttpsPort = 5986;
+        private const string DefaultApplicationName = "/wsman";
+
+        public override string ComputerName { get; set; }
+
+        /// <summary>Port number. If 0, uses 5985 (HTTP) or 5986 (HTTPS).</summary>
+        public int Port { get; set; }
+
+        /// <summary>Use HTTPS (port 5986 by default).</summary>
+        public bool UseSSL { get; set; }
+
+        /// <summary>Authentication mechanism (Basic, Negotiate, etc.).</summary>
+        public WinRMAuthenticationMechanism Authentication { get; set; }
+
+        /// <summary>WSMan application name path (default "/wsman").</summary>
+        public string ApplicationName { get; set; }
+
+        /// <summary>PowerShell session configuration name (e.g. "Microsoft.PowerShell", "PowerShell.7").</summary>
+        public string ConfigurationName { get; set; }
+
+        /// <summary>Whether to follow HTTP redirects.</summary>
+        public bool AllowRedirection { get; set; }
+
+        public override PSCredential? Credential { get; set; }
+
+        /// <summary>Use the current Windows logon token instead of an explicit PSCredential.</summary>
+        public bool UseImplicitCredential { get; set; }
+
+        public override AuthenticationMechanism AuthenticationMechanism
+        {
+            get => AuthenticationMechanism.Default;
+            set => throw new NotImplementedException();
+        }
+
+        public override string CertificateThumbprint
+        {
+            get => string.Empty;
+            set => throw new NotImplementedException();
+        }
+
+        public WinRMClientInfo(string computerName)
+        {
+            ComputerName = computerName ?? throw new ArgumentNullException(nameof(computerName));
+            ApplicationName = DefaultApplicationName;
+            ConfigurationName = WsManXml.DefaultConfigurationName;
+            Authentication = WinRMAuthenticationMechanism.Negotiate;
+        }
+
+        /// <summary>Effective port: uses 5985/5986 if Port is 0.</summary>
+        public int EffectivePort => Port > 0 ? Port : (UseSSL ? DefaultHttpsPort : DefaultHttpPort);
+
+        /// <summary>Full HTTP/HTTPS endpoint URI for WSMan requests.</summary>
+        public string BuildEndpointUri()
+        {
+            string scheme = UseSSL ? "https" : "http";
+            return $"{scheme}://{ComputerName}:{EffectivePort}{ApplicationName}";
+        }
+
+        public override RunspaceConnectionInfo Clone()
+        {
+            return new WinRMClientInfo(ComputerName)
+            {
+                Port = Port,
+                UseSSL = UseSSL,
+                Authentication = Authentication,
+                ApplicationName = ApplicationName,
+                ConfigurationName = ConfigurationName,
+                AllowRedirection = AllowRedirection,
+                Credential = Credential,
+                UseImplicitCredential = UseImplicitCredential,
+                OpenTimeout = OpenTimeout,
+                CancelTimeout = CancelTimeout,
+                OperationTimeout = OperationTimeout,
+                IdleTimeout = IdleTimeout
+            };
+        }
+
+        public override BaseClientSessionTransportManager CreateClientSessionTransportManager(
+            Guid instanceId,
+            string sessionName,
+            PSRemotingCryptoHelper cryptoHelper)
+        {
+            return new WinRMClientSessionTransportMgr(this, instanceId, cryptoHelper);
+        }
+    }
+
+    /// <summary>
+    /// Helpers for building and parsing WSMan SOAP XML messages.
+    /// Uses string templates to avoid XML namespace declaration issues.
+    /// </summary>
+    internal static class WsManXml
+    {
+        // WSMan namespace URIs
+        public const string NsSoap = "http://www.w3.org/2003/05/soap-envelope";
+        public const string NsWsa  = "http://schemas.xmlsoap.org/ws/2004/08/addressing";
+        public const string NsWsMan = "http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd";
+        public const string NsRsp  = "http://schemas.microsoft.com/wbem/wsman/1/windows/shell";
+
+        public const string ResourceUriBase = "http://schemas.microsoft.com/powershell/";
+        public const string DefaultConfigurationName = "Microsoft.PowerShell";
+
+        public static string GetResourceUri(string configurationName) =>
+            ResourceUriBase + (string.IsNullOrEmpty(configurationName) ? DefaultConfigurationName : configurationName);
+
+        public const string ActionCreate  = "http://schemas.xmlsoap.org/ws/2004/09/transfer/Create";
+        public const string ActionDelete  = "http://schemas.xmlsoap.org/ws/2004/09/transfer/Delete";
+        public const string ActionSend    = "http://schemas.microsoft.com/wbem/wsman/1/windows/shell/Send";
+        public const string ActionReceive = "http://schemas.microsoft.com/wbem/wsman/1/windows/shell/Receive";
+        public const string ActionCommand = "http://schemas.microsoft.com/wbem/wsman/1/windows/shell/Command";
+        public const string ActionSignal  = "http://schemas.microsoft.com/wbem/wsman/1/windows/shell/Signal";
+
+        private const string SoapPrologue =
+            "<s:Envelope xmlns:s=\"http://www.w3.org/2003/05/soap-envelope\"" +
+            " xmlns:wsa=\"http://schemas.xmlsoap.org/ws/2004/08/addressing\"" +
+            " xmlns:wsman=\"http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd\"" +
+            " xmlns:rsp=\"http://schemas.microsoft.com/wbem/wsman/1/windows/shell\"" +
+            " xmlns:pwsh=\"http://schemas.microsoft.com/powershell\">";
+
+        private static string BuildHeader(string to, string action, string msgId, string? shellId, string? configurationName = null, string? extraHeaders = null, string operationTimeout = "PT60.000S")
+        {
+            var sb = new StringBuilder();
+            string resourceUri = GetResourceUri(configurationName ?? DefaultConfigurationName);
+            sb.Append("<s:Header>");
+            sb.Append($"<wsa:To>{to}</wsa:To>");
+            sb.Append($"<wsman:ResourceURI>{resourceUri}</wsman:ResourceURI>");
+            sb.Append("<wsa:ReplyTo><wsa:Address>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</wsa:Address></wsa:ReplyTo>");
+            sb.Append($"<wsa:Action>{action}</wsa:Action>");
+            sb.Append($"<wsa:MessageID>uuid:{msgId}</wsa:MessageID>");
+            sb.Append("<wsman:MaxEnvelopeSize>512000</wsman:MaxEnvelopeSize>");
+            sb.Append("<wsman:Locale xml:lang=\"en-US\"/>");
+            sb.Append("<wsman:DataLocale xml:lang=\"en-US\"/>");
+            sb.Append($"<wsman:OperationTimeout>{operationTimeout}</wsman:OperationTimeout>");
+
+            if (shellId != null)
+            {
+                sb.Append("<wsman:SelectorSet>");
+                sb.Append($"<wsman:Selector Name=\"ShellId\">{shellId}</wsman:Selector>");
+                sb.Append("</wsman:SelectorSet>");
+            }
+
+            if (extraHeaders != null)
+                sb.Append(extraHeaders);
+
+            sb.Append("</s:Header>");
+            return sb.ToString();
+        }
+
+        public static string BuildCreateShell(string endpoint, string msgId, string? configurationName = null, string? initialPsrpData = null)
+        {
+            // protocolversion=2.3 is required by the Windows PS remoting plugin (pwrshplugin.dll).
+            // Without it in the OptionSet, wsmprovhost.exe throws a NullReferenceException during CreateShell.
+            const string optionSet =
+                "<wsman:OptionSet xmlns:xsi=\"http://www.w3.org/1999/XMLSchema-instance\">" +
+                "<wsman:Option Name=\"protocolversion\">2.3</wsman:Option>" +
+                "</wsman:OptionSet>";
+            string header = BuildHeader(endpoint, ActionCreate, msgId, null, configurationName, optionSet);
+            string body =
+                "<s:Body>" +
+                "<rsp:Shell>" +
+                "<rsp:InputStreams>stdin pr</rsp:InputStreams>" +
+                "<rsp:OutputStreams>stdout</rsp:OutputStreams>" +
+                (string.IsNullOrEmpty(initialPsrpData) ? string.Empty : $"<pwsh:creationXml>{initialPsrpData}</pwsh:creationXml>") +
+                "</rsp:Shell>" +
+                "</s:Body>";
+            return SoapPrologue + header + body + "</s:Envelope>";
+        }
+
+        public static string BuildSend(string endpoint, string msgId, string shellId, string? commandId, string base64Data, string? configurationName = null, string inputStreamName = "stdin")
+        {
+            string header = BuildHeader(endpoint, ActionSend, msgId, shellId, configurationName);
+            string streamAttr = commandId != null ? $" CommandId=\"{commandId}\"" : "";
+            string body =
+                "<s:Body>" +
+                "<rsp:Send>" +
+                $"<rsp:Stream Name=\"{inputStreamName}\"{streamAttr}>{base64Data}</rsp:Stream>" +
+                "</rsp:Send>" +
+                "</s:Body>";
+            return SoapPrologue + header + body + "</s:Envelope>";
+        }
+
+        public static string BuildReceive(string endpoint, string msgId, string shellId, string? commandId, string? configurationName = null)
+        {
+            // WSMAN_CMDSHELL_OPTION_KEEPALIVE=TRUE tells the server to hold the long-poll
+            // connection open and send data as it becomes available (required for PSRP).
+            const string optionSet =
+                "<wsman:OptionSet xmlns:xsi=\"http://www.w3.org/1999/XMLSchema-instance\">" +
+                "<wsman:Option Name=\"WSMAN_CMDSHELL_OPTION_KEEPALIVE\">TRUE</wsman:Option>" +
+                "</wsman:OptionSet>";
+            string header = BuildHeader(endpoint, ActionReceive, msgId, shellId, configurationName, optionSet, "PT1.000S");
+            string streamAttr = commandId != null ? $" CommandId=\"{commandId}\"" : "";
+            string body =
+                "<s:Body>" +
+                "<rsp:Receive>" +
+                $"<rsp:DesiredStream{streamAttr}>stdout</rsp:DesiredStream>" +
+                "</rsp:Receive>" +
+                "</s:Body>";
+            return SoapPrologue + header + body + "</s:Envelope>";
+        }
+
+        public static string BuildDelete(string endpoint, string msgId, string shellId, string? configurationName = null)
+        {
+            string header = BuildHeader(endpoint, ActionDelete, msgId, shellId, configurationName);
+            return SoapPrologue + header + "<s:Body/></s:Envelope>";
+        }
+
+        public static string BuildRunCommand(string endpoint, string msgId, string shellId, string pipelineGuid, string? base64PsrpData = null, string? configurationName = null)
+        {
+            // Native PS7 client (WSManRunShellCommandEx) sends:
+            //   commandId   = PowershellInstanceId (pipeline GUID) → maps to CommandId attribute on CommandLine
+            //   commandLine = " " (single space)
+            //   argSet      = serialized PSRP data (the first message, e.g. PublicKey) → maps to <rsp:Arguments>
+            //   options     = IntPtr.Zero (no OptionSet)
+            // pwrshplugin.dll requires the PSRP data in <rsp:Arguments> to create the pipeline context;
+            // without it, it returns HTTP 500 "fatal error while processing WSManPluginCommand arguments".
+            string header = BuildHeader(endpoint, ActionCommand, msgId, shellId, configurationName);
+            string args = base64PsrpData != null ? $"<rsp:Arguments>{base64PsrpData}</rsp:Arguments>" : string.Empty;
+            string body =
+                "<s:Body>" +
+                $"<rsp:CommandLine CommandId=\"{pipelineGuid}\">" +
+                "<rsp:Command> </rsp:Command>" +
+                args +
+                "</rsp:CommandLine>" +
+                "</s:Body>";
+            return SoapPrologue + header + body + "</s:Envelope>";
+        }
+
+        public static string BuildSignal(string endpoint, string msgId, string shellId, string commandId, string? configurationName = null)
+        {
+            string header = BuildHeader(endpoint, ActionSignal, msgId, shellId, configurationName);
+            string body =
+                "<s:Body>" +
+                $"<rsp:Signal CommandId=\"{commandId}\">" +
+                "<rsp:Code>http://schemas.microsoft.com/wbem/wsman/1/windows/shell/signal/terminate</rsp:Code>" +
+                "</rsp:Signal>" +
+                "</s:Body>";
+            return SoapPrologue + header + body + "</s:Envelope>";
+        }
+
+        /// <summary>
+        /// Parses a RunCommand response and returns the CommandId, or null if not found.
+        /// </summary>
+        public static string? ParseCommandId(string responseXml)
+        {
+            try
+            {
+                var doc = XDocument.Parse(responseXml);
+                XNamespace rsp = NsRsp;
+                var el = doc.Descendants(rsp + "CommandId").GetEnumerator();
+                if (el.MoveNext())
+                    return el.Current.Value;
+                return null;
+            }
+            catch { return null; }
+        }
+
+        /// <summary>
+        /// Parses a CreateShell response and returns the ShellId, or null if not found.
+        /// </summary>
+        public static string? ParseShellId(string responseXml)
+        {
+            try
+            {
+                var doc = XDocument.Parse(responseXml);
+                XNamespace rsp = NsRsp;
+                XNamespace wsman = NsWsMan;
+
+                // Try body: <rsp:Shell><rsp:ShellId>
+                var shellIdEl = doc.Descendants(rsp + "ShellId").GetEnumerator();
+                if (shellIdEl.MoveNext())
+                    return shellIdEl.Current.Value;
+
+                // Try header SelectorSet: <wsman:Selector Name="ShellId">
+                foreach (var sel in doc.Descendants(wsman + "Selector"))
+                {
+                    if ((string?)sel.Attribute("Name") == "ShellId")
+                        return sel.Value;
+                }
+
+                return null;
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Parses a ReceiveResponse and returns streams keyed by name (e.g. "stdout", "stderr").
+        /// </summary>
+        public static IEnumerable<(string Name, string Base64Data)> ParseStreams(string responseXml)
+        {
+            XNamespace rsp = NsRsp;
+            XDocument doc;
+            try { doc = XDocument.Parse(responseXml); }
+            catch { yield break; }
+
+            foreach (var stream in doc.Descendants(rsp + "Stream"))
+            {
+                string? name = (string?)stream.Attribute("Name");
+                string? data = stream.Value;
+                if (!string.IsNullOrEmpty(name) && !string.IsNullOrEmpty(data))
+                    yield return (name, data);
+            }
+        }
+
+        /// <summary>
+        /// Extracts the base64 PSRP fragment content from a PSRP stdio Data element.
+        /// Input format: <Data Stream='Default' PSGuid='GUID'>BASE64</Data>
+        /// Returns the BASE64 string for use in WinRM SOAP stream elements.
+        /// </summary>
+        public static string ExtractBase64FromDataElement(string dataLine)
+        {
+            int gtPos = dataLine.IndexOf('>');
+            int ltPos = dataLine.LastIndexOf('<');
+            if (gtPos >= 0 && ltPos > gtPos)
+                return dataLine.Substring(gtPos + 1, ltPos - gtPos - 1);
+            return dataLine; // fallback: return as-is
+        }
+
+        /// <summary>
+        /// Extracts the PSGuid attribute value from a PSRP stdio Data element.
+        /// Input format: &lt;Data Stream='Default' PSGuid='GUID'&gt;BASE64&lt;/Data&gt;
+        /// Returns the GUID string (without braces) or null if not found.
+        /// </summary>
+        public static string? ExtractPsGuidFromDataElement(string dataLine)
+        {
+            int idx = dataLine.IndexOf("PSGuid='", StringComparison.OrdinalIgnoreCase);
+            char quote = '\'';
+            if (idx < 0) { idx = dataLine.IndexOf("PSGuid=\"", StringComparison.OrdinalIgnoreCase); quote = '"'; }
+            if (idx < 0) return null;
+            int start = idx + 8; // skip PSGuid=' (8 chars)
+            int end = dataLine.IndexOf(quote, start);
+            if (end < 0) return null;
+            return dataLine.Substring(start, end - start);
+        }
+
+        public static string? ExtractStreamNameFromDataElement(string dataLine)
+        {
+            int idx = dataLine.IndexOf("Stream='", StringComparison.OrdinalIgnoreCase);
+            char quote = '\'';
+            if (idx < 0) { idx = dataLine.IndexOf("Stream=\"", StringComparison.OrdinalIgnoreCase); quote = '"'; }
+            if (idx < 0) return null;
+            int start = idx + 8; // skip Stream=' (8 chars)
+            int end = dataLine.IndexOf(quote, start);
+            if (end < 0) return null;
+            return dataLine.Substring(start, end - start);
+        }
+
+        /// <summary>
+        /// Wraps a base64 PSRP fragment in a stdio Data element for use with HandleOutputDataReceived.
+        /// Output format: <Data Stream="Default" PSGuid="GUID">BASE64</Data>
+        /// Both Stream and PSGuid attributes are required by the PSRP base class parser.
+        /// The PSGuid is extracted from the binary PSRP fragment to enable correct pipeline routing.
+        /// </summary>
+        public static string WrapInDataElement(string base64Data, Dictionary<ulong, string> fragmentGuids)
+        {
+            string psGuid = ExtractPsGuidFromFragment(base64Data, fragmentGuids);
+            return $"<Data Stream='Default' PSGuid='{psGuid}'>{base64Data}</Data>";
+        }
+
+        /// <summary>
+        /// Extracts the PSGuid from a binary PSRP fragment for reconstructing stdio Data elements.
+        /// Tracks multi-fragment object IDs in <paramref name="fragmentGuids"/>.
+        /// For START fragments: reads RunspacePool GUID and Pipeline GUID from the message header.
+        /// For continuation fragments: looks up the stored GUID by ObjectId.
+        /// </summary>
+        public static string ExtractPsGuidFromFragment(string base64Data, Dictionary<ulong, string>? fragmentGuids = null)
+        {
+            const string zero = "00000000-0000-0000-0000-000000000000";
+            try
+            {
+                byte[] bytes = Convert.FromBase64String(base64Data);
+                // Fragment header: ObjectId(8) + FragmentId(8) + Flags(1) + BlobLength(4) = 21 bytes
+                if (bytes.Length < 21) return zero;
+
+                ulong objectId = BitConverter.ToUInt64(bytes, 0);
+                byte flags = bytes[16];
+                bool isStart = (flags & 0x02) != 0;
+                bool isEnd   = (flags & 0x01) != 0;
+
+                if (isStart)
+                {
+                    // Message header after 21-byte fragment header:
+                    // Destination(4) + MessageType(4) + RunspacePoolId(16) + PipelineId(16)
+                    if (bytes.Length < 61) return zero;
+                    var rpid = new Guid(bytes[29..45]);
+                    var pid  = new Guid(bytes[45..61]);
+                    // Session-level messages use PSGuid=zeros so they route to _sessionMessageQueue.
+                    // Command-level messages use PipelineId so they route to _commandMessageQueue.
+                    // (NOT the actual RPID — the session queue consumer handles all non-pipeline PSRP messages.)
+                    string psGuid = pid == Guid.Empty ? zero : pid.ToString();
+
+                    if (fragmentGuids != null && !isEnd)
+                        fragmentGuids[objectId] = psGuid; // store for continuation fragments
+                    else if (fragmentGuids != null && isEnd)
+                        fragmentGuids.Remove(objectId);
+
+                    return psGuid;
+                }
+                else if (fragmentGuids != null && fragmentGuids.TryGetValue(objectId, out string? stored))
+                {
+                    if (isEnd) fragmentGuids.Remove(objectId);
+                    return stored;
+                }
+                return zero;
+            }
+            catch { return zero; }
+        }
+
+
+        public static bool IsFault(string responseXml)
+        {
+            try
+            {
+                var doc = XDocument.Parse(responseXml);
+                XNamespace soap = NsSoap;
+                return doc.Descendants(soap + "Fault").GetEnumerator().MoveNext();
+            }
+            catch { return false; }
+        }
+
+        /// <summary>
+        /// Returns true when the SOAP fault is a <c>w:TimedOut</c> — the WinRM long-poll
+        /// "no data available" signal. This is normal; the caller should simply re-poll.
+        /// </summary>
+        public static bool IsTimeoutFault(string responseXml)
+        {
+            try
+            {
+                var doc = XDocument.Parse(responseXml);
+                return doc.Descendants()
+                    .Any(e => e.Name.LocalName == "Value"
+                           && e.Parent?.Name.LocalName == "Subcode"
+                           && e.Value.EndsWith("TimedOut", StringComparison.OrdinalIgnoreCase));
+            }
+            catch { return false; }
+        }
+    }
+
+    /// <summary>
+    /// Custom TextWriter that sends PSRP data via WSMan Send requests.
+    /// The PSRP base class calls WriteLine() to transmit each protocol message.
+    /// </summary>
+    internal sealed class WinRMTextWriter : TextWriter
+    {
+        private readonly WinRMClientSessionTransportMgr _transport;
+
+        public WinRMTextWriter(WinRMClientSessionTransportMgr transport)
+        {
+            _transport = transport ?? throw new ArgumentNullException(nameof(transport));
+        }
+
+        public override Encoding Encoding => Encoding.UTF8;
+
+        public override void WriteLine(string? value)
+        {
+            if (value != null)
+                _transport.SendPsrpLine(value);
+        }
+
+        public override void Write(string? value)
+        {
+            if (value != null)
+                _transport.SendPsrpLine(value);
+        }
+
+        public override void Write(char value)
+        {
+            _transport.SendPsrpLine(value.ToString());
+        }
+
+        public override void Flush() { }
+    }
+
+    /// <summary>
+    /// WinRM transport manager using HttpClient and WSMan SOAP protocol.
+    /// Implements custom PSRemoting transport that communicates via HTTP POST requests.
+    /// </summary>
+    internal sealed class WinRMClientSessionTransportMgr : ClientSessionTransportManagerBase
+    {
+        private readonly WinRMClientInfo _connectionInfo;
+        private readonly Guid _runspaceId;
+        private readonly PSRemotingCryptoHelper? _cryptoHelper; // stored from constructor for key exchange bypass
+        private readonly System.Diagnostics.Stopwatch _sw = System.Diagnostics.Stopwatch.StartNew();
+        private string T => $"+{_sw.ElapsedMilliseconds,6}ms";
+        private HttpClient? _httpClient;
+        private string? _shellId;
+        private volatile string? _commandId;          // WinRM CommandId for current active pipeline
+        private volatile string? _commandPipelineGuid; // PSRP PipelineId matching _commandId
+        private volatile string? _pendingRunCommandGuid; // pipeline GUID awaiting first <Data> to trigger RunCommand
+        private volatile int _runCommandCount;         // number of RunCommand calls made (first = key exchange)
+        private string? _keyExchangePublicKeyB64;      // saved PUBLIC_KEY fragment for RSA encryption of injected key
+        private volatile bool _publicKeyRequestInjected;
+        private volatile bool _keyExchangeInjected;    // true once we have injected the synthetic EncryptedSessionKey
+        private volatile bool _pendingEncryptedSessionKeyInjection;
+        private volatile bool _encryptedSessionKeyInjectionScheduled;
+        private bool _sessionStateLoggingHooked;
+        private CancellationTokenSource? _readerCts;
+        private volatile bool _isClosed;
+        // Tracks multi-fragment PSRP object GUIDs for PSGuid reconstruction on receive
+        private readonly Dictionary<ulong, string> _receiveFragmentGuids = new();
+
+        private const string ReaderThreadName = "WinRM Transport Reader Thread";
+
+        internal WinRMClientSessionTransportMgr(
+            WinRMClientInfo connectionInfo,
+            Guid runspaceId,
+            PSRemotingCryptoHelper cryptoHelper)
+            : base(runspaceId, cryptoHelper)
+        {
+            _connectionInfo = connectionInfo ?? throw new PSArgumentException(nameof(connectionInfo));
+            _runspaceId = runspaceId;
+            _cryptoHelper = cryptoHelper;
+        }
+
+        public override void CreateAsync()
+        {
+            // Do NOT block here — blocking the PS pipeline thread prevents state change events
+            // from being processed, causing WaitOne in CreateAndOpenRunspace to never unblock.
+            Task.Run(async () =>
+            {
+                try
+                {
+                    await CreateConnectionAsync().ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    HandleTransportError(new PSRemotingTransportException(
+                        $"Failed to establish WinRM connection to '{_connectionInfo.ComputerName}': {ex.Message}", ex));
+                }
+            });
+        }
+
+        private bool UsesSspiAuthentication =>
+            _connectionInfo.Authentication == WinRMAuthenticationMechanism.Negotiate
+            || _connectionInfo.Authentication == WinRMAuthenticationMechanism.Default
+            || _connectionInfo.Authentication == WinRMAuthenticationMechanism.Kerberos;
+
+        private HttpMessageHandler CreateHttpHandler()
+        {
+            return new HttpClientHandler
+            {
+                AllowAutoRedirect = _connectionInfo.AllowRedirection,
+                PreAuthenticate = false
+            };
+        }
+
+        private async Task CreateConnectionAsync()
+        {
+            HttpMessageHandler handler = CreateHttpHandler();
+
+            _httpClient = new HttpClient(handler)
+            {
+                Timeout = TimeSpan.FromSeconds(120)
+            };
+
+            byte[]? initialSessionData = TryReadInitialSessionData();
+
+            // Create the remote shell and get ShellId
+            _shellId = await CreateShellAsync(initialSessionData).ConfigureAwait(false);
+            WinRMTrace.WriteLine($"[WINRM-DBG {T}] CreateShell OK, ShellId={_shellId}");
+            WinRMTrace.WriteLine($"[WINRM-DBG] RunspaceInstanceId={_runspaceId}");
+            TryHookSessionStateLogging();
+
+            // PSRP over WinRM does NOT use RunCommand. Unlike WinRS (which runs cmd.exe commands),
+            // PSRP sends protocol messages directly to the shell via Send/Receive without a command context.
+            // The ShellId selector (set on all requests) is sufficient to identify the PS session.
+
+            // Set up PSRP writer - PSRP base class calls WriteLine() on this
+            SetMessageWriter(new WinRMTextWriter(this));
+            RaiseCreateCompletedCompat();
+            QueueDataAck(null);
+
+            // Start the reader thread that polls Receive
+            _readerCts = new CancellationTokenSource();
+            StartReaderThread();
+        }
+
+        private async Task<string> CreateShellAsync(byte[]? initialPsrpData = null)
+        {
+            string endpoint = _connectionInfo.BuildEndpointUri();
+            string msgId = Guid.NewGuid().ToString().ToUpper();
+            string? initialPsrpDataB64 = initialPsrpData != null && initialPsrpData.Length > 0
+                ? Convert.ToBase64String(initialPsrpData)
+                : null;
+            string soapXml = WsManXml.BuildCreateShell(endpoint, msgId, _connectionInfo.ConfigurationName, initialPsrpDataB64);
+
+            string response = await PostSoapAsync(endpoint, soapXml, WsManXml.ActionCreate)
+                .ConfigureAwait(false);
+
+            string? shellId = WsManXml.ParseShellId(response);
+            if (string.IsNullOrEmpty(shellId))
+                throw new InvalidOperationException(
+                    "WinRM server did not return a ShellId in the CreateShell response");
+
+            return shellId;
+        }
+
+        private async Task<string> RunCommandAsync(string shellId)
+        {
+            string endpoint = _connectionInfo.BuildEndpointUri();
+            string msgId = Guid.NewGuid().ToString().ToUpper();
+            string soapXml = WsManXml.BuildRunCommand(endpoint, msgId, shellId, _connectionInfo.ConfigurationName);
+
+            string response = await PostSoapAsync(endpoint, soapXml, WsManXml.ActionCommand)
+                .ConfigureAwait(false);
+
+            // Real WinRM returns a distinct CommandId; our custom server may return ShellId
+            string? commandId = WsManXml.ParseCommandId(response) ?? WsManXml.ParseShellId(response);
+            if (string.IsNullOrEmpty(commandId))
+                throw new InvalidOperationException(
+                    "WinRM server did not return a CommandId in the RunCommand response");
+
+            return commandId;
+        }
+
+        /// <summary>
+        /// Called by WinRMTextWriter to send a PSRP protocol line via WSMan Send.
+        /// The line is UTF-8 encoded then Base64-encoded into the SOAP stream element.
+        /// </summary>
+        internal void SendPsrpLine(string line)
+        {
+            if (_isClosed || _shellId == null || _httpClient == null) return;
+
+            WinRMTrace.WriteLine($"[WINRM-DBG] SendPsrpLine RAW len={line.Length} first40=[{line.Substring(0, Math.Min(40, line.Length))}]");
+
+            try
+            {
+                string trimmedLine = line.TrimEnd('\n', '\r').TrimStart();
+
+                // <Command PSGuid='GUID' /> — PSRP pipeline creation signal.
+                // Per the PS7 WinRM transport (WSManRunShellCommandEx), the pipeline GUID goes as
+                // CommandId on CommandLine, and the FIRST PSRP data fragment goes as <rsp:Arguments>.
+                // So we defer the RunCommand until we see the first <Data> for this pipeline GUID.
+                if (trimmedLine.StartsWith("<Command ", StringComparison.OrdinalIgnoreCase))
+                {
+                    string? pipelineGuid = ExtractPsGuidAttribute(trimmedLine);
+                    if (pipelineGuid != null && _shellId != null)
+                    {
+                        // Remember this pipeline GUID: the next <Data PSGuid='GUID'> will trigger RunCommand.
+                        _pendingRunCommandGuid = pipelineGuid;
+
+                        // Inject a synthetic <CommandAck> to unblock the PS SDK consumer so it
+                        // proceeds to send the first <Data> (PublicKey for key exchange).
+                        // Use Task.Run to avoid reentrancy (consumer exits SendPsrpLine first).
+                        var ackGuid = pipelineGuid;
+                        _ = Task.Run(async () =>
+                        {
+                            await Task.Delay(50);
+                            HandleOutputDataReceived($"<CommandAck PSGuid='{ackGuid}'/>");
+                        });
+                    }
+                    return;
+                }
+
+                // <Close PSGuid='GUID' /> — PSRP pipeline close.
+                // Signal terminate on the command context, then clear it.
+                if (trimmedLine.StartsWith("<Close ", StringComparison.OrdinalIgnoreCase))
+                {
+                    string closeGuid = ExtractPsGuidAttribute(trimmedLine) ?? Guid.Empty.ToString();
+                    string? closingCommandId = _commandId;
+                    if (closingCommandId != null && _shellId != null)
+                    {
+                        _commandId = null;
+                        _commandPipelineGuid = null;
+                        string endpoint = _connectionInfo.BuildEndpointUri();
+                        string sigMsgId = Guid.NewGuid().ToString().ToUpper();
+                        string sigSoap = WsManXml.BuildSignal(endpoint, sigMsgId, _shellId, closingCommandId, _connectionInfo.ConfigurationName);
+                        try { PostSoapAsync(endpoint, sigSoap, WsManXml.ActionSignal).GetAwaiter().GetResult(); } catch { /* best effort */ }
+                    }
+
+                    // Native WSMan transport reports command/session close completion through transport callbacks
+                    // rather than out-of-proc text packets. Synthesize the expected CloseAck control packet so the
+                    // client transport managers can finish their close bookkeeping.
+                    var ackGuid = closeGuid;
+                    _ = Task.Run(async () =>
+                    {
+                        await Task.Delay(50).ConfigureAwait(false);
+                        HandleOutputDataReceived($"<CloseAck PSGuid='{ackGuid}'/>");
+                    });
+                    return;
+                }
+
+                // Regular <Data Stream='Default' PSGuid='GUID'>BASE64</Data> message.
+                // Extract the base64 payload and send via WinRM Send.
+                string base64Data = WsManXml.ExtractBase64FromDataElement(trimmedLine);
+                if (string.IsNullOrEmpty(base64Data) || base64Data.TrimStart().StartsWith("<"))
+                {
+                    WinRMTrace.WriteLine($"[WINRM-DBG] SendPsrpLine SKIPPED (not a Data element)");
+                    return;
+                }
+
+                // Decode the PSRP fragment to detect message types relevant to key exchange.
+                // After we inject PublicKeyRequest the client should send an actual PUBLIC_KEY
+                // session message, and only then should we inject EncryptedSessionKey.
+                try
+                {
+                    byte[] outFrag = Convert.FromBase64String(base64Data);
+                    if (outFrag.Length >= 29)
+                    {
+                        byte outFlags = outFrag[16];
+                        bool outIsStart = (outFlags & 0x02) != 0;
+                        if (outIsStart)
+                        {
+                            uint outMt = BitConverter.ToUInt32(outFrag, 25);
+                            WinRMTrace.WriteLine($"[WINRM-DBG] OUTGOING MsgType=0x{outMt:X8} Flags=0x{outFlags:X2} b64Len={base64Data.Length} reqInjected={_publicKeyRequestInjected} keyInjected={_keyExchangeInjected}");
+                            if (outMt == 0x00010005)
+                            {
+                                _keyExchangePublicKeyB64 = base64Data;
+                                WinRMTrace.WriteLine($"[WINRM-DBG] PUBLIC_KEY (0x{outMt:X8}) saved for RSA injection");
+                                WinRMTrace.WriteLine($"[WINRM-DBG] OUTGOING FULL_B64={base64Data}");
+                                WinRMTrace.WriteLine($"[WINRM-DBG] Session state at PUBLIC_KEY send: {GetCurrentSessionState()}");
+
+                                if (_publicKeyRequestInjected && !_keyExchangeInjected)
+                                {
+                                    _pendingEncryptedSessionKeyInjection = true;
+                                    WinRMTrace.WriteLine($"[WINRM-DBG {T}] PublicKey observed after PublicKeyRequest - waiting for command setup before EncryptedSessionKey");
+                                }
+                            }
+                            else if (outMt == 0x00021006 && !_keyExchangeInjected)
+                            {
+                                if (_publicKeyRequestInjected)
+                                {
+                                    _pendingEncryptedSessionKeyInjection = true;
+                                    WinRMTrace.WriteLine($"[WINRM-DBG {T}] CreatePowerShell observed after PublicKeyRequest - waiting for command setup before EncryptedSessionKey");
+                                }
+                                else
+                                {
+                                    WinRMTrace.WriteLine($"[WINRM-DBG {T}] CreatePowerShell observed with no key request pending");
+                                }
+                            }
+                        }
+                    }
+                }
+                catch { }
+
+                // If this is the first <Data> for a pending pipeline, send RunCommand with the data
+                // as <rsp:Arguments> (matching what WSManRunShellCommandEx sends natively).
+                // pwrshplugin.dll requires the PSRP data in <rsp:Arguments> to initialize the pipeline.
+                string? dataPipelineGuid = WsManXml.ExtractPsGuidFromDataElement(trimmedLine);
+                if (dataPipelineGuid != null && dataPipelineGuid.Equals(_pendingRunCommandGuid, StringComparison.OrdinalIgnoreCase) && _shellId != null)
+                {
+                    _pendingRunCommandGuid = null;
+                    try
+                    {
+                        string ep = _connectionInfo.BuildEndpointUri();
+                        string cmdMsgId = Guid.NewGuid().ToString().ToUpper();
+                        string cmdSoap = WsManXml.BuildRunCommand(ep, cmdMsgId, _shellId, dataPipelineGuid, base64Data, _connectionInfo.ConfigurationName);
+                        WinRMTrace.WriteLine($"[WINRM-DBG {T}] RunCommand+Args for pipeline {dataPipelineGuid}");
+                        string cmdResponse = PostSoapAsync(ep, cmdSoap, WsManXml.ActionCommand).GetAwaiter().GetResult();
+                        string? newCommandId = WsManXml.ParseCommandId(cmdResponse) ?? WsManXml.ParseShellId(cmdResponse);
+                        WinRMTrace.WriteLine($"[WINRM-DBG {T}] RunCommand OK → commandId={newCommandId}");
+                        _commandId = newCommandId;
+                        _commandPipelineGuid = dataPipelineGuid;
+
+                        System.Threading.Interlocked.Increment(ref _runCommandCount);
+                        if (_pendingEncryptedSessionKeyInjection)
+                        {
+                            WinRMTrace.WriteLine($"[WINRM-DBG {T}] RunCommand established for key exchange pipeline");
+                        }
+
+                        if (newCommandId != null)
+                        {
+                            var capturedCommandId = newCommandId;
+                            var capturedCts = _readerCts;
+                            _ = Task.Run(() => DrainCommandReceive(capturedCommandId, capturedCts?.Token ?? CancellationToken.None));
+                        }
+                        QueueDataAck(dataPipelineGuid);
+                        return;
+                    }
+                    catch (Exception runCmdEx)
+                    {
+                        WinRMTrace.WriteLine($"[WINRM-DBG] RunCommand+Args failed: {runCmdEx.Message.Split('\n')[0]}");
+                        // Fall through to try a plain shell-level Send as last resort.
+                    }
+                }
+
+                string endpoint2 = _connectionInfo.BuildEndpointUri();
+                string msgId = Guid.NewGuid().ToString().ToUpper();
+                string outOfProcStream = WsManXml.ExtractStreamNameFromDataElement(trimmedLine) ?? "Default";
+                string wsManInputStream = string.Equals(outOfProcStream, "PromptResponse", StringComparison.OrdinalIgnoreCase) ? "pr" : "stdin";
+                bool isSessionLevelMessage = string.IsNullOrEmpty(dataPipelineGuid) ||
+                    string.Equals(dataPipelineGuid, Guid.Empty.ToString(), StringComparison.OrdinalIgnoreCase);
+                string? targetCommandId = isSessionLevelMessage ? null : _commandId;
+                string soapXml = WsManXml.BuildSend(endpoint2, msgId, _shellId!, targetCommandId, base64Data, _connectionInfo.ConfigurationName, wsManInputStream);
+
+                WinRMTrace.WriteLine($"[WINRM-DBG] SEND b64.len={base64Data.Length} commandId={targetCommandId ?? "null"} stream={outOfProcStream}->{wsManInputStream}");
+                PostSoapAsync(endpoint2, soapXml, WsManXml.ActionSend).GetAwaiter().GetResult();
+                WinRMTrace.WriteLine($"[WINRM-DBG] SEND OK");
+                QueueDataAck(dataPipelineGuid);
+            }
+            catch (Exception ex) when (!_isClosed)
+            {
+                WinRMTrace.WriteLine($"[WINRM-DBG] SEND ERROR: {ex.Message}");
+                HandleTransportError(new PSRemotingTransportException(
+                    $"WinRM Send failed: {ex.Message}", ex));
+            }
+        }
+
+        private void TryInjectPendingEncryptedSessionKey(string reason)
+        {
+            if (!_pendingEncryptedSessionKeyInjection || _keyExchangeInjected || _commandId == null || _encryptedSessionKeyInjectionScheduled)
+            {
+                return;
+            }
+
+            _encryptedSessionKeyInjectionScheduled = true;
+            _ = Task.Run(async () =>
+            {
+                await Task.Delay(50).ConfigureAwait(false);
+                _encryptedSessionKeyInjectionScheduled = false;
+                if (!_pendingEncryptedSessionKeyInjection || _keyExchangeInjected || _commandId == null)
+                {
+                    WinRMTrace.WriteLine($"[WINRM-DBG {T}] {reason} - synthetic EncryptedSessionKey cancelled");
+                    return;
+                }
+
+                _pendingEncryptedSessionKeyInjection = false;
+                _keyExchangeInjected = true;
+                WinRMTrace.WriteLine($"[WINRM-DBG {T}] {reason} - injecting EncryptedSessionKey");
+                InjectSyntheticEncryptedSessionKey();
+            });
+        }
+
+        private void ObserveRealEncryptedSessionKey(string source)
+        {
+            _pendingEncryptedSessionKeyInjection = false;
+            _keyExchangeInjected = true;
+            WinRMTrace.WriteLine($"[WINRM-DBG {T}] Real EncryptedSessionKey received via {source}; synthetic injection disabled; state={GetCurrentSessionState()}");
+        }
+
+        /// <summary>
+        /// Extracts the PSGuid attribute value from a PSRP control element.
+        /// Handles both single-quote and double-quote attribute delimiters.
+        /// </summary>
+        private static string? ExtractPsGuidAttribute(string line)
+        {
+            // Look for PSGuid='...' or PSGuid="..."
+            int idx = line.IndexOf("PSGuid='", StringComparison.OrdinalIgnoreCase);
+            char quote = '\'';
+            if (idx < 0) { idx = line.IndexOf("PSGuid=\"", StringComparison.OrdinalIgnoreCase); quote = '"'; }
+            if (idx < 0) return null;
+            idx += 8; // skip PSGuid=' or PSGuid="
+            int end = line.IndexOf(quote, idx);
+            return end > idx ? line.Substring(idx, end - idx) : null;
+        }
+
+        private async Task<string> PostSoapAsync(string endpoint, string soapXml, string action)
+        {
+            if (_httpClient == null)
+                throw new ObjectDisposedException(nameof(_httpClient));
+
+            return UsesSspiAuthentication
+                ? await PostSoapWithSspiAuthAsync(endpoint, soapXml, action).ConfigureAwait(false)
+                : await PostSoapCoreAsync(endpoint, soapXml, action, null).ConfigureAwait(false);
+        }
+
+        private async Task<string> PostSoapWithSspiAuthAsync(string endpoint, string soapXml, string action)
+        {
+            Uri endpointUri = new(endpoint);
+            IWinRMNegotiateAuthContext? authContext = null;
+            AuthenticationHeaderValue? authorizationHeader = null;
+
+            try
+            {
+                for (int attempt = 0; attempt < 6; attempt++)
+                {
+                    using HttpResponseMessage response = await SendSoapRequestAsync(endpoint, soapXml, action, authorizationHeader).ConfigureAwait(false);
+                    string body = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+
+                    if (response.IsSuccessStatusCode)
+                    {
+                        if (authContext != null
+                            && !authContext.Complete
+                            && TryGetAuthenticateToken(response, authContext.HttpAuthLabel, out string? finalToken)
+                            && !string.IsNullOrWhiteSpace(finalToken))
+                        {
+                            authContext.Step(Convert.FromBase64String(finalToken));
+                        }
+
+                        return body;
+                    }
+
+                    if (response.StatusCode == HttpStatusCode.Unauthorized)
+                    {
+                        authContext ??= WinRMSspiProviderFactory.CreateContext(_connectionInfo, endpointUri);
+                        if (!TryGetAuthenticateToken(response, authContext.HttpAuthLabel, out string? serverToken))
+                        {
+                            throw new InvalidOperationException(
+                                $"WinRM server at '{endpoint}' rejected {authContext.HttpAuthLabel} authentication without a usable WWW-Authenticate challenge.");
+                        }
+
+                        byte[]? outgoingToken = authContext.Step(
+                            !string.IsNullOrWhiteSpace(serverToken)
+                                ? Convert.FromBase64String(serverToken)
+                                : null);
+
+                        authorizationHeader = outgoingToken != null && outgoingToken.Length > 0
+                            ? new AuthenticationHeaderValue(
+                                authContext.HttpAuthLabel,
+                                Convert.ToBase64String(outgoingToken))
+                            : null;
+
+                        WinRMTrace.WriteLine($"[WINRM-DBG {T}] HTTP 401 received for {authContext.HttpAuthLabel}; continuing SSPI handshake");
+                        continue;
+                    }
+
+                    // w:TimedOut is the WinRM long-poll "no data available" signal — not a real error.
+                    // The reader thread should simply re-poll on an empty return value.
+                    if (response.StatusCode == HttpStatusCode.InternalServerError
+                        && WsManXml.IsTimeoutFault(body))
+                        return string.Empty;
+
+                    throw new InvalidOperationException(
+                        $"WSMan request to '{endpoint}' failed with HTTP {(int)response.StatusCode}: {body}");
+                }
+
+                throw new InvalidOperationException(
+                    $"Exceeded WinRM authentication retries for '{endpoint}'.");
+            }
+            finally
+            {
+                authContext?.Dispose();
+            }
+        }
+
+        private async Task<string> PostSoapCoreAsync(
+            string endpoint,
+            string soapXml,
+            string action,
+            AuthenticationHeaderValue? authorizationHeader)
+        {
+            using HttpResponseMessage response = await SendSoapRequestAsync(endpoint, soapXml, action, authorizationHeader).ConfigureAwait(false);
+            string body = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                // w:TimedOut is the WinRM long-poll "no data available" signal — not a real error.
+                // The reader thread should simply re-poll on an empty return value.
+                if (response.StatusCode == HttpStatusCode.InternalServerError
+                    && WsManXml.IsTimeoutFault(body))
+                    return string.Empty;
+
+                throw new InvalidOperationException(
+                    $"WSMan request to '{endpoint}' failed with HTTP {(int)response.StatusCode}: {body}");
+            }
+
+            return body;
+        }
+
+        private Task<HttpResponseMessage> SendSoapRequestAsync(
+            string endpoint,
+            string soapXml,
+            string action,
+            AuthenticationHeaderValue? authorizationHeader)
+        {
+            var request = new HttpRequestMessage(HttpMethod.Post, endpoint)
+            {
+                Content = new StringContent(soapXml, Encoding.UTF8, "application/soap+xml")
+            };
+            request.Headers.Add("SOAPAction", action);
+            if (authorizationHeader != null)
+            {
+                request.Headers.Authorization = authorizationHeader;
+            }
+
+            if (_connectionInfo.Authentication == WinRMAuthenticationMechanism.Basic
+                && _connectionInfo.Credential != null)
+            {
+                NetworkCredential networkCredential = _connectionInfo.Credential.GetNetworkCredential();
+                string basicCredential = $"{networkCredential.UserName}:{networkCredential.Password}";
+                request.Headers.Authorization = new AuthenticationHeaderValue(
+                    "Basic",
+                    Convert.ToBase64String(Encoding.UTF8.GetBytes(basicCredential)));
+            }
+            else if (_connectionInfo.Authentication == WinRMAuthenticationMechanism.Basic)
+            {
+                throw new InvalidOperationException("WinRM Basic authentication requires explicit credentials.");
+            }
+
+            return _httpClient!.SendAsync(request);
+        }
+
+        private static bool TryGetAuthenticateToken(
+            HttpResponseMessage response,
+            string scheme,
+            out string? token)
+        {
+            token = null;
+
+            foreach (AuthenticationHeaderValue header in response.Headers.WwwAuthenticate)
+            {
+                if (string.Equals(header.Scheme, scheme, StringComparison.OrdinalIgnoreCase))
+                {
+                    token = string.IsNullOrWhiteSpace(header.Parameter) ? null : header.Parameter;
+                    return true;
+                }
+            }
+
+            if (!response.Headers.TryGetValues("WWW-Authenticate", out IEnumerable<string>? values))
+            {
+                return false;
+            }
+
+            foreach (string rawValue in values)
+            {
+                foreach (string part in rawValue.Split(','))
+                {
+                    string candidate = part.Trim();
+                    if (!candidate.StartsWith(scheme, StringComparison.OrdinalIgnoreCase))
+                    {
+                        continue;
+                    }
+
+                    token = candidate.Length == scheme.Length
+                        ? null
+                        : candidate.Substring(scheme.Length).Trim();
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private void StartReaderThread()
+        {
+            var thread = new Thread(ProcessReaderThread)
+            {
+                Name = ReaderThreadName,
+                IsBackground = true
+            };
+            thread.Start();
+        }
+
+        private byte[]? TryReadInitialSessionData()
+        {
+            try
+            {
+                var queue = FindField(typeof(BaseClientTransportManager), "dataToBeSent")?.GetValue(this);
+                if (queue == null)
+                {
+                    return null;
+                }
+
+                var method = queue.GetType().GetMethod(
+                    "ReadOrRegisterCallback",
+                    System.Reflection.BindingFlags.Instance |
+                    System.Reflection.BindingFlags.Public |
+                    System.Reflection.BindingFlags.NonPublic);
+
+                if (method == null)
+                {
+                    return null;
+                }
+
+                var parameters = method.GetParameters();
+                object?[] args = new object?[parameters.Length];
+                args[0] = null;
+                if (parameters.Length > 1)
+                {
+                    Type outType = parameters[1].ParameterType.GetElementType() ?? parameters[1].ParameterType;
+                    args[1] = Activator.CreateInstance(outType);
+                }
+
+                byte[]? data = method.Invoke(queue, args) as byte[];
+                if (data != null && data.Length > 0)
+                {
+                    WinRMTrace.WriteLine($"[WINRM-DBG] Initial session payload queued ({data.Length} bytes)");
+                }
+
+                return data;
+            }
+            catch (Exception ex)
+            {
+                WinRMTrace.WriteLine($"[WINRM-DBG] TryReadInitialSessionData failed: {ex.GetType().Name}: {ex.Message}");
+                return null;
+            }
+        }
+
+        private void ProcessRawDataCompat(byte[] data, string stream)
+        {
+            try
+            {
+                typeof(BaseClientTransportManager).GetMethod(
+                    "ProcessRawData",
+                    System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic,
+                    binder: null,
+                    types: new[] { typeof(byte[]), typeof(string) },
+                    modifiers: null)
+                    ?.Invoke(this, new object[] { data, stream });
+            }
+            catch (Exception ex)
+            {
+                WinRMTrace.WriteLine($"[WINRM-DBG] ProcessRawDataCompat failed: {ex.GetType().Name}: {ex.Message}");
+            }
+        }
+
+        private void RaiseCreateCompletedCompat()
+        {
+            try
+            {
+                const System.Reflection.BindingFlags flags =
+                    System.Reflection.BindingFlags.Instance |
+                    System.Reflection.BindingFlags.NonPublic |
+                    System.Reflection.BindingFlags.Public;
+
+                Type? eventArgsType = typeof(BaseClientTransportManager).Assembly
+                    .GetType("System.Management.Automation.Remoting.CreateCompleteEventArgs");
+                var ctor = eventArgsType?.GetConstructor(
+                    flags,
+                    binder: null,
+                    types: new[] { typeof(RunspaceConnectionInfo) },
+                    modifiers: null);
+                object? eventArgs = ctor?.Invoke(new object[] { _connectionInfo.Clone() });
+                if (eventArgs == null)
+                {
+                    WinRMTrace.WriteLine("[WINRM-DBG] RaiseCreateCompletedCompat could not construct CreateCompleteEventArgs");
+                    return;
+                }
+
+                typeof(BaseClientTransportManager).GetMethod("RaiseCreateCompleted", flags)
+                    ?.Invoke(this, new[] { eventArgs });
+                WinRMTrace.WriteLine("[WINRM-DBG] Raised CreateCompleted");
+            }
+            catch (Exception ex)
+            {
+                WinRMTrace.WriteLine($"[WINRM-DBG] RaiseCreateCompletedCompat failed: {ex.GetType().Name}: {ex.Message}");
+            }
+        }
+
+        private void QueueDataAck(string? psGuid)
+        {
+            string ackGuid = string.IsNullOrWhiteSpace(psGuid) ? Guid.Empty.ToString() : psGuid;
+            _ = Task.Run(async () =>
+            {
+                await Task.Delay(10).ConfigureAwait(false);
+                HandleOutputDataReceived($"<DataAck PSGuid='{ackGuid}'/>");
+            });
+        }
+
+        private byte[]? BuildEncodedPsrpMessage(string encoderMethodName, params object[] args)
+        {
+            try
+            {
+                Type? encoderType = typeof(PSObject).Assembly.GetType("System.Management.Automation.RemotingEncoder");
+                var encoderMethod = encoderType?.GetMethod(
+                    encoderMethodName,
+                    System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.NonPublic);
+                if (encoderMethod == null)
+                {
+                    return null;
+                }
+
+                object? remoteDataObject = encoderMethod.Invoke(null, args);
+                if (remoteDataObject == null)
+                {
+                    return null;
+                }
+
+                object? fragmentor = typeof(BaseClientTransportManager).GetProperty(
+                    "Fragmentor",
+                    System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.NonPublic)
+                    ?.GetValue(this);
+
+                if (fragmentor == null)
+                {
+                    return null;
+                }
+
+                using var ms = new MemoryStream();
+                remoteDataObject.GetType().GetMethod(
+                    "Serialize",
+                    System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.NonPublic,
+                    binder: null,
+                    types: new[] { typeof(Stream), fragmentor.GetType() },
+                    modifiers: null)
+                    ?.Invoke(remoteDataObject, new object[] { ms, fragmentor });
+
+                return ms.ToArray();
+            }
+            catch (Exception ex)
+            {
+                WinRMTrace.WriteLine($"[WINRM-DBG] BuildEncodedPsrpMessage({encoderMethodName}) failed: {ex.GetType().Name}: {ex.Message}");
+                return null;
+            }
+        }
+
+        private bool TryInjectEncodedPsrpMessage(string encoderMethodName, params object[] encoderArgs)
+        {
+            try
+            {
+                byte[]? data = BuildEncodedPsrpMessage(encoderMethodName, encoderArgs);
+                if (data == null || data.Length == 0)
+                {
+                    WinRMTrace.WriteLine($"[WINRM-DBG] TryInjectEncodedPsrpMessage({encoderMethodName}) produced no data");
+                    return false;
+                }
+
+                string wrappedData = WsManXml.WrapInDataElement(Convert.ToBase64String(data), _receiveFragmentGuids);
+                WinRMTrace.WriteLine($"[WINRM-DBG] Injecting encoded {encoderMethodName} via HandleOutputDataReceived ({data.Length} bytes)");
+                HandleOutputDataReceived(wrappedData);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                WinRMTrace.WriteLine($"[WINRM-DBG] TryInjectEncodedPsrpMessage({encoderMethodName}) failed: {ex.GetType().Name}: {ex.Message}");
+                return false;
+            }
+        }
+
+        private bool TryRaiseKeyExchangeMessage(string encoderMethodName, params object[] encoderArgs)
+        {
+            try
+            {
+                const System.Reflection.BindingFlags flags =
+                    System.Reflection.BindingFlags.Instance |
+                    System.Reflection.BindingFlags.NonPublic |
+                    System.Reflection.BindingFlags.Public;
+                const System.Reflection.BindingFlags staticFlags =
+                    System.Reflection.BindingFlags.Static |
+                    System.Reflection.BindingFlags.NonPublic |
+                    System.Reflection.BindingFlags.Public;
+
+                var asm = typeof(PSObject).Assembly;
+                var encoderType = asm.GetType("System.Management.Automation.RemotingEncoder");
+                var encoderMethod = encoderType?.GetMethod(encoderMethodName, staticFlags);
+                object? remoteDataObject = encoderMethod?.Invoke(null, encoderArgs);
+                if (remoteDataObject == null || _cryptoHelper == null)
+                {
+                    return false;
+                }
+
+                Type remoteDataObjectType = remoteDataObject.GetType();
+                object? destination = remoteDataObjectType.GetProperty("Destination", flags)?.GetValue(remoteDataObject);
+                object? dataType = remoteDataObjectType.GetProperty("DataType", flags)?.GetValue(remoteDataObject);
+                Guid runspacePoolId = (Guid)(remoteDataObjectType.GetProperty("RunspacePoolId", flags)?.GetValue(remoteDataObject) ?? Guid.Empty);
+                Guid powerShellId = (Guid)(remoteDataObjectType.GetProperty("PowerShellId", flags)?.GetValue(remoteDataObject) ?? Guid.Empty);
+                object? data = remoteDataObjectType.GetProperty("Data", flags)?.GetValue(remoteDataObject);
+
+                Type? genericRemoteDataType = asm.GetType("System.Management.Automation.Remoting.RemoteDataObject`1")?.MakeGenericType(typeof(PSObject));
+                var createFrom = genericRemoteDataType?.GetMethods(staticFlags)
+                    .FirstOrDefault(m => m.Name == "CreateFrom" && m.GetParameters().Length == 5);
+                if (createFrom == null || destination == null || dataType == null)
+                {
+                    WinRMTrace.WriteLine($"[WINRM-DBG] TryRaiseKeyExchangeMessage({encoderMethodName}) missing CreateFrom or metadata");
+                    return false;
+                }
+
+                object psData = data as PSObject ?? PSObject.AsPSObject(data ?? string.Empty);
+                object? typedRemoteData = createFrom.Invoke(null, new[] { destination, dataType, runspacePoolId, powerShellId, psData });
+                if (typedRemoteData == null)
+                {
+                    WinRMTrace.WriteLine($"[WINRM-DBG] TryRaiseKeyExchangeMessage({encoderMethodName}) CreateFrom returned null");
+                    return false;
+                }
+
+                object? session = _cryptoHelper.GetType().GetProperty("Session", flags)?.GetValue(_cryptoHelper)
+                    ?? FindField(_cryptoHelper.GetType(), "<Session>k__BackingField")?.GetValue(_cryptoHelper);
+                object? dataStructureHandler = session != null
+                    ? FindField(session.GetType(), "<BaseSessionDataStructureHandler>k__BackingField")?.GetValue(session)
+                    : null;
+                var raiseMethod = dataStructureHandler?.GetType().GetMethod("RaiseKeyExchangeMessageReceived", flags);
+                if (raiseMethod == null)
+                {
+                    WinRMTrace.WriteLine($"[WINRM-DBG] TryRaiseKeyExchangeMessage({encoderMethodName}) missing RaiseKeyExchangeMessageReceived");
+                    return false;
+                }
+                raiseMethod?.Invoke(dataStructureHandler, new[] { typedRemoteData });
+                return true;
+            }
+            catch (Exception ex)
+            {
+                WinRMTrace.WriteLine($"[WINRM-DBG] TryRaiseKeyExchangeMessage({encoderMethodName}) failed: {ex.GetType().Name}: {ex.Message}");
+                WinRMTrace.WriteLine($"[WINRM-DBG]   detail: {ex}");
+                if (ex is System.Reflection.TargetInvocationException tie && tie.InnerException != null)
+                {
+                    WinRMTrace.WriteLine($"[WINRM-DBG]   inner: {tie.InnerException.GetType().Name}: {tie.InnerException.Message}");
+                    WinRMTrace.WriteLine($"[WINRM-DBG]   inner detail: {tie.InnerException}");
+                }
+                return false;
+            }
+        }
+
+        private void InjectPublicKeyRequest()
+        {
+            try
+            {
+                _publicKeyRequestInjected = true;
+                WinRMTrace.WriteLine($"[WINRM-DBG {T}] Injecting synthetic PublicKeyRequest");
+                if (TryRaiseKeyExchangeMessage("GeneratePublicKeyRequest", _runspaceId))
+                {
+                    WinRMTrace.WriteLine($"[WINRM-DBG {T}] Synthetic PublicKeyRequest via hook injected OK");
+                    return;
+                }
+
+                WinRMTrace.WriteLine("[WINRM-DBG] Hook PublicKeyRequest injection failed; falling back to encoded data");
+                if (!TryInjectEncodedPsrpMessage("GeneratePublicKeyRequest", _runspaceId))
+                {
+                    WinRMTrace.WriteLine("[WINRM-DBG] Failed to inject PublicKeyRequest");
+                    return;
+                }
+                WinRMTrace.WriteLine($"[WINRM-DBG {T}] Synthetic PublicKeyRequest via encoded data injected OK");
+            }
+            catch (Exception ex)
+            {
+                WinRMTrace.WriteLine($"[WINRM-DBG] InjectPublicKeyRequest failed: {ex.GetType().Name}: {ex.Message}");
+            }
+        }
+
+        /// <summary>
+        /// Disables PSRP session-level key exchange in the CryptoHelper via reflection.
+        /// PS5.1 WinRM servers do not send EncryptedSessionKey; transport-level NTLM/Kerberos
+        /// encryption already protects the channel. With key exchange disabled, the PS SDK's
+        /// ImportEncryptedSessionKey becomes a no-op and accepts a synthetic reply.
+        /// </summary>
+        private void TryDisableKeyExchange()
+        {
+            try
+            {
+                if (_cryptoHelper == null)
+                {
+                    WinRMTrace.WriteLine("[WINRM-DBG] TryDisableKeyExchange: _cryptoHelper is null");
+                    return;
+                }
+
+                // Try direct field on PSRemotingCryptoHelper
+                if (TrySetField(_cryptoHelper, "_isKeyExchangeEnabled", false)) return;
+
+                // In PS 7.x the flag lives on the Session object held by the helper.
+                var sessionField = _cryptoHelper.GetType().GetField("<Session>k__BackingField",
+                    System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+                var session = sessionField?.GetValue(_cryptoHelper);
+                if (session != null && TrySetField(session, "_isKeyExchangeEnabled", false)) return;
+
+                WinRMTrace.WriteLine("[WINRM-DBG] TryDisableKeyExchange: field not found anywhere in helper/session hierarchy");
+            }
+            catch (Exception ex)
+            {
+                WinRMTrace.WriteLine($"[WINRM-DBG] TryDisableKeyExchange failed: {ex.Message}");
+            }
+        }
+
+        private static System.Reflection.FieldInfo? FindField(Type? type, string fieldName)
+        {
+            while (type != null && type != typeof(object))
+            {
+                var field = type.GetField(fieldName,
+                    System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Public);
+                if (field != null)
+                {
+                    return field;
+                }
+                type = type.BaseType;
+            }
+            return null;
+        }
+
+        private static bool TrySetField(object obj, string fieldName, object value)
+        {
+            var field = FindField(obj.GetType(), fieldName);
+            if (field == null)
+            {
+                return false;
+            }
+
+            field.SetValue(obj, value);
+            WinRMTrace.WriteLine($"[WINRM-DBG] Set {field.DeclaringType?.Name ?? obj.GetType().Name}.{fieldName} = {value}");
+            return true;
+        }
+
+        private string GetCurrentSessionState()
+        {
+            const System.Reflection.BindingFlags flags =
+                System.Reflection.BindingFlags.Instance |
+                System.Reflection.BindingFlags.NonPublic |
+                System.Reflection.BindingFlags.Public;
+
+            try
+            {
+                if (_cryptoHelper == null)
+                {
+                    return "<no-crypto-helper>";
+                }
+
+                object? session = _cryptoHelper.GetType().GetProperty("Session", flags)?.GetValue(_cryptoHelper)
+                    ?? FindField(_cryptoHelper.GetType(), "<Session>k__BackingField")?.GetValue(_cryptoHelper);
+                object? dataStructureHandler = session != null
+                    ? FindField(session.GetType(), "<BaseSessionDataStructureHandler>k__BackingField")?.GetValue(session)
+                    : null;
+                object? stateMachine = dataStructureHandler != null
+                    ? FindField(dataStructureHandler.GetType(), "_stateMachine")?.GetValue(dataStructureHandler)
+                    : null;
+                object? state = stateMachine?.GetType().GetProperty("State", flags)?.GetValue(stateMachine);
+                return state?.ToString() ?? "<unknown>";
+            }
+            catch (Exception ex)
+            {
+                return $"<state-error:{ex.GetType().Name}>";
+            }
+        }
+
+        private void TryHookSessionStateLogging()
+        {
+            if (_sessionStateLoggingHooked || _cryptoHelper == null)
+            {
+                return;
+            }
+
+            const System.Reflection.BindingFlags flags =
+                System.Reflection.BindingFlags.Instance |
+                System.Reflection.BindingFlags.NonPublic |
+                System.Reflection.BindingFlags.Public;
+
+            try
+            {
+                object? session = _cryptoHelper.GetType().GetProperty("Session", flags)?.GetValue(_cryptoHelper)
+                    ?? FindField(_cryptoHelper.GetType(), "<Session>k__BackingField")?.GetValue(_cryptoHelper);
+                if (session == null)
+                {
+                    WinRMTrace.WriteLine("[WINRM-DBG] Remote session object not available for StateChanged hook");
+                    return;
+                }
+
+                var eventInfo = session.GetType().GetEvent("StateChanged", flags);
+                if (eventInfo?.EventHandlerType == null)
+                {
+                    WinRMTrace.WriteLine("[WINRM-DBG] Remote session StateChanged event not found");
+                    return;
+                }
+
+                var handlerMethod = GetType().GetMethod(nameof(OnRemoteSessionStateChanged), flags);
+                if (handlerMethod == null)
+                {
+                    WinRMTrace.WriteLine("[WINRM-DBG] OnRemoteSessionStateChanged method not found");
+                    return;
+                }
+
+                Delegate? handler = Delegate.CreateDelegate(eventInfo.EventHandlerType, this, handlerMethod, false);
+                if (handler == null)
+                {
+                    WinRMTrace.WriteLine("[WINRM-DBG] Unable to bind remote session StateChanged handler");
+                    return;
+                }
+
+                eventInfo.AddEventHandler(session, handler);
+                _sessionStateLoggingHooked = true;
+                WinRMTrace.WriteLine("[WINRM-DBG] Hooked remote session StateChanged logging");
+            }
+            catch (Exception ex)
+            {
+                WinRMTrace.WriteLine($"[WINRM-DBG] Failed to hook remote session StateChanged: {ex.GetType().Name}: {ex.Message}");
+            }
+        }
+
+        private void OnRemoteSessionStateChanged(object? sender, EventArgs eventArgs)
+        {
+            try
+            {
+                object? sessionStateInfo = eventArgs.GetType().GetProperty("SessionStateInfo")?.GetValue(eventArgs);
+                object? state = sessionStateInfo?.GetType().GetProperty("State")?.GetValue(sessionStateInfo);
+                object? reason = sessionStateInfo?.GetType().GetProperty("Reason")?.GetValue(sessionStateInfo);
+                WinRMTrace.WriteLine($"[WINRM-DBG {T}] REMOTE SESSION STATE: {state} Reason={reason}");
+            }
+            catch (Exception ex)
+            {
+                WinRMTrace.WriteLine($"[WINRM-DBG] REMOTE SESSION STATE logging failed: {ex.GetType().Name}: {ex.Message}");
+            }
+        }
+
+        private static void TryRaiseSessionStateEvent(object stateMachine, string eventName)
+        {
+            const System.Reflection.BindingFlags flags =
+                System.Reflection.BindingFlags.Instance |
+                System.Reflection.BindingFlags.NonPublic |
+                System.Reflection.BindingFlags.Public;
+
+            var asm = typeof(PSObject).Assembly;
+            Type? remoteSessionEventType = asm.GetType("System.Management.Automation.RemoteSessionEvent");
+            Type? eventArgsType = asm.GetType("System.Management.Automation.RemoteSessionStateMachineEventArgs");
+            if (remoteSessionEventType == null || eventArgsType == null)
+            {
+                return;
+            }
+
+            object? eventValue = Enum.Parse(remoteSessionEventType, eventName);
+            object? eventArgs = eventArgsType.GetConstructor(new[] { remoteSessionEventType })?.Invoke(new[] { eventValue });
+            stateMachine.GetType().GetMethod("RaiseEvent", flags)?.Invoke(stateMachine, new object?[] { eventArgs, false });
+        }
+
+        private void TryStartKeyExchangeLocally()
+        {
+            if (_cryptoHelper == null)
+            {
+                return;
+            }
+
+            const System.Reflection.BindingFlags flags =
+                System.Reflection.BindingFlags.Instance |
+                System.Reflection.BindingFlags.NonPublic |
+                System.Reflection.BindingFlags.Public;
+
+            try
+            {
+                object? session = _cryptoHelper.GetType().GetProperty("Session", flags)?.GetValue(_cryptoHelper)
+                    ?? FindField(_cryptoHelper.GetType(), "<Session>k__BackingField")?.GetValue(_cryptoHelper);
+                object? dataStructureHandler = session != null
+                    ? FindField(session.GetType(), "<BaseSessionDataStructureHandler>k__BackingField")?.GetValue(session)
+                    : null;
+                object? stateMachine = dataStructureHandler != null
+                    ? FindField(dataStructureHandler.GetType(), "_stateMachine")?.GetValue(dataStructureHandler)
+                    : null;
+                object? stateBefore = stateMachine?.GetType().GetProperty("State", flags)?.GetValue(stateMachine);
+                WinRMTrace.WriteLine($"[WINRM-DBG] Session state before StartKeyExchange: {stateBefore}");
+
+                if (string.Equals(stateBefore?.ToString(), "Established", StringComparison.Ordinal))
+                {
+                    session?.GetType().GetMethod("StartKeyExchange", flags)?.Invoke(session, null);
+                }
+
+                object? stateAfter = stateMachine?.GetType().GetProperty("State", flags)?.GetValue(stateMachine);
+                WinRMTrace.WriteLine($"[WINRM-DBG] Session state after StartKeyExchange: {stateAfter}");
+            }
+            catch (Exception ex)
+            {
+                WinRMTrace.WriteLine($"[WINRM-DBG] TryStartKeyExchangeLocally failed: {ex.GetType().Name}: {ex.Message}");
+            }
+        }
+
+        private bool TryCompleteKeyExchangeLocally(string encryptedKeyB64)
+        {
+            if (_cryptoHelper == null || string.IsNullOrEmpty(encryptedKeyB64))
+            {
+                return false;
+            }
+
+            try
+            {
+                const System.Reflection.BindingFlags flags =
+                    System.Reflection.BindingFlags.Instance |
+                    System.Reflection.BindingFlags.NonPublic |
+                    System.Reflection.BindingFlags.Public;
+
+                Type helperType = _cryptoHelper.GetType();
+                helperType.GetMethod("RunKeyExchangeIfRequired", flags)?.Invoke(_cryptoHelper, null);
+
+                bool imported = helperType.GetMethod("ImportEncryptedSessionKey", flags)?.Invoke(_cryptoHelper, new object[] { encryptedKeyB64 }) as bool? ?? false;
+                WinRMTrace.WriteLine($"[WINRM-DBG] ImportEncryptedSessionKey returned {imported}");
+                if (!imported)
+                {
+                    return false;
+                }
+
+                helperType.GetMethod("CompleteKeyExchange", flags)?.Invoke(_cryptoHelper, null);
+
+                if (FindField(helperType, "_keyExchangeCompleted")?.GetValue(_cryptoHelper) is EventWaitHandle keyExchangeCompleted)
+                {
+                    keyExchangeCompleted.Set();
+                    WinRMTrace.WriteLine("[WINRM-DBG] Signaled helper key exchange event");
+                }
+
+                object? session = helperType.GetProperty("Session", flags)?.GetValue(_cryptoHelper)
+                    ?? FindField(helperType, "<Session>k__BackingField")?.GetValue(_cryptoHelper);
+
+                if (session != null)
+                {
+                    Type sessionType = session.GetType();
+                    sessionType.GetMethod("CompleteKeyExchange", flags)?.Invoke(session, null);
+
+                    object? dataStructureHandler = FindField(sessionType, "<BaseSessionDataStructureHandler>k__BackingField")?.GetValue(session);
+                    object? stateMachine = dataStructureHandler != null
+                        ? FindField(dataStructureHandler.GetType(), "_stateMachine")?.GetValue(dataStructureHandler)
+                        : null;
+
+                    if (stateMachine != null)
+                    {
+                        Type stateMachineType = stateMachine.GetType();
+                        object? stateBefore = stateMachineType.GetProperty("State", flags)?.GetValue(stateMachine);
+                        WinRMTrace.WriteLine($"[WINRM-DBG] Session state before local completion event: {stateBefore}");
+
+                        if (string.Equals(stateBefore?.ToString(), "Established", StringComparison.Ordinal))
+                        {
+                            TryRaiseSessionStateEvent(stateMachine, "KeyRequested");
+                            TryRaiseSessionStateEvent(stateMachine, "KeySent");
+                        }
+
+                        TrySetField(stateMachine, "_keyExchanged", true);
+                        TryRaiseSessionStateEvent(stateMachine, "KeyReceived");
+
+                        object? stateAfter = stateMachineType.GetProperty("State", flags)?.GetValue(stateMachine);
+                        WinRMTrace.WriteLine($"[WINRM-DBG] Session state after local completion event: {stateAfter}");
+                    }
+                }
+
+                return true;
+            }
+            catch (Exception ex)
+            {
+                WinRMTrace.WriteLine($"[WINRM-DBG] TryCompleteKeyExchangeLocally failed: {ex.GetType().Name}: {ex.Message}");
+                WinRMTrace.WriteLine($"[WINRM-DBG]   detail: {ex}");
+                if (ex is System.Reflection.TargetInvocationException tie && tie.InnerException != null)
+                {
+                    WinRMTrace.WriteLine($"[WINRM-DBG]   inner: {tie.InnerException.GetType().Name}: {tie.InnerException.Message}");
+                    WinRMTrace.WriteLine($"[WINRM-DBG]   inner detail: {tie.InnerException}");
+                }
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Injects a synthetic ENCRYPTED_SESSION_KEY (MsgType=0x0002100B) PSRP fragment.
+        /// If we have the outgoing PUBLIC_KEY fragment saved, we extract the client's RSA public key,
+        /// generate a random 32-byte session key, RSA-encrypt it (PKCS1v15), and inject that.
+        /// The PS SDK will decrypt it successfully with its private key and complete key exchange,
+        /// transitioning the runspace to Opened without needing to disable key exchange via reflection.
+        /// </summary>
+        private void InjectSyntheticEncryptedSessionKey()
+        {
+            try
+            {
+                string encryptedKeyB64 = BuildEncryptedSessionKeyPayload();
+                TryStartKeyExchangeLocally();
+                WinRMTrace.WriteLine($"[WINRM-DBG {T}] Injecting synthetic EncryptedSessionKey");
+                if (TryRaiseKeyExchangeMessage("GenerateEncryptedSessionKeyResponse", _runspaceId, encryptedKeyB64))
+                {
+                    WinRMTrace.WriteLine($"[WINRM-DBG {T}] Synthetic EncryptedSessionKey via hook injected OK");
+                    WinRMTrace.WriteLine($"[WINRM-DBG] Session state immediately after hook: {GetCurrentSessionState()}");
+                    Thread.Sleep(50);
+                    WinRMTrace.WriteLine($"[WINRM-DBG] Session state 50ms after hook: {GetCurrentSessionState()}");
+                    return;
+                }
+
+                WinRMTrace.WriteLine("[WINRM-DBG] Hook EncryptedSessionKey injection failed; falling back to encoded data");
+                if (!TryInjectEncodedPsrpMessage("GenerateEncryptedSessionKeyResponse", _runspaceId, encryptedKeyB64))
+                {
+                    WinRMTrace.WriteLine("[WINRM-DBG] Encoded EncryptedSessionKey injection failed; trying local key completion fallback");
+                    if (!TryCompleteKeyExchangeLocally(encryptedKeyB64))
+                    {
+                        WinRMTrace.WriteLine("[WINRM-DBG] Failed to inject EncryptedSessionKey");
+                        return;
+                    }
+
+                    WinRMTrace.WriteLine($"[WINRM-DBG {T}] Local key completion fallback succeeded");
+                    return;
+                }
+                WinRMTrace.WriteLine($"[WINRM-DBG {T}] Synthetic EncryptedSessionKey via hook injected OK");
+                WinRMTrace.WriteLine($"[WINRM-DBG] Session state immediately after hook: {GetCurrentSessionState()}");
+                Thread.Sleep(50);
+                WinRMTrace.WriteLine($"[WINRM-DBG] Session state 50ms after hook: {GetCurrentSessionState()}");
+            }
+            catch (Exception ex)
+            {
+                WinRMTrace.WriteLine($"[WINRM-DBG] InjectSyntheticEncryptedSessionKey failed: {ex.GetType().Name}: {ex.Message}");
+            }
+        }
+
+        /// <summary>
+        /// Builds the base64-encoded encrypted session key to use in the injected ENCRYPTED_SESSION_KEY message.
+        /// If <see cref="_keyExchangePublicKeyB64"/> was saved from the outgoing PUBLIC_KEY fragment, this method
+        /// extracts the client's RSA public key from it, generates a random 32-byte session key, and returns its
+        /// RSA-PKCS1v15 encryption as base64.  If anything fails it falls back to "AAAA" (which will fail RSA
+        /// decryption but is harmless when key exchange gets disabled via reflection).
+        /// </summary>
+        private string BuildEncryptedSessionKeyPayload()
+        {
+            // Strategy: export the client's RSA public key from the live crypto helper,
+            // encrypt a random AES session key with it, then wrap the RSA ciphertext in the
+            // CAPI SIMPLEBLOB format that ImportEncryptedSessionKey expects.
+            if (_cryptoHelper != null)
+            {
+                try
+                {
+                    var helperType = _cryptoHelper.GetType();
+                    var method = helperType.GetMethod(
+                        "ExportLocalPublicKey",
+                        System.Reflection.BindingFlags.Instance |
+                        System.Reflection.BindingFlags.Public   |
+                        System.Reflection.BindingFlags.NonPublic);
+
+                    if (method != null)
+                    {
+                        // ExportLocalPublicKey has one out/ref string parameter.
+                        object[] args = new object[] { null! };
+                        method.Invoke(_cryptoHelper, args);
+                        string? pubKeyB64 = args[0] as string;
+
+                        WinRMTrace.WriteLine($"[WINRM-DBG] ExportLocalPublicKey result (first 60): {pubKeyB64?.Substring(0, Math.Min(60, pubKeyB64?.Length ?? 0))}");
+
+                        if (!string.IsNullOrEmpty(pubKeyB64))
+                        {
+                            // pubKeyB64 = base64-encoded Windows CAPI PUBLICKEYBLOB
+                            byte[] cspBlob = Convert.FromBase64String(pubKeyB64);
+                            WinRMTrace.WriteLine($"[WINRM-DBG] CSP blob length: {cspBlob.Length}, type byte: 0x{cspBlob[0]:X2}");
+
+                            byte[] sessionKey = new byte[32];
+                            System.Security.Cryptography.RandomNumberGenerator.Fill(sessionKey);
+
+                            var rsaProvider = new System.Security.Cryptography.RSACryptoServiceProvider();
+                            rsaProvider.ImportCspBlob(cspBlob);
+                            byte[] enc = rsaProvider.Encrypt(sessionKey, false); // false = PKCS1v15
+                            byte[] simpleBlob = new byte[12 + enc.Length];
+                            simpleBlob[0] = 0x01; // SIMPLEBLOB
+                            simpleBlob[1] = 0x02; // CUR_BLOB_VERSION
+                            simpleBlob[4] = 0x10; // CALG_AES_256 low byte
+                            simpleBlob[5] = 0x66; // CALG_AES_256 high byte
+                            simpleBlob[9] = 0xA4; // CALG_RSA_KEYX low byte
+                            for (int i = 0; i < enc.Length; i++)
+                            {
+                                simpleBlob[12 + i] = enc[enc.Length - 1 - i];
+                            }
+
+                            WinRMTrace.WriteLine($"[WINRM-DBG] RSA encrypt OK ({enc.Length} bytes), SIMPLEBLOB len={simpleBlob.Length}");
+                            return Convert.ToBase64String(simpleBlob);
+                        }
+                    }
+                }
+                catch (Exception ex)
+                {
+                    WinRMTrace.WriteLine($"[WINRM-DBG] RSA via ExportLocalPublicKey failed: {ex.GetType().Name}: {ex.Message}");
+                }
+            }
+
+            WinRMTrace.WriteLine("[WINRM-DBG] RSA key extraction failed; using AAAA fallback");
+            return "AAAA";
+        }
+
+
+        /// the command stream; this task drains those until the command completes or the
+        /// shell is closed. The main reader thread handles shell-level messages in parallel.
+        /// <para>
+        /// When <paramref name="isKeyExchangePipeline"/> is true, the server is expected to
+        /// complete key exchange by sending PipelineState=Done without EncryptedSessionKey
+        /// (PS5.1 WinRM behaviour). After PipelineState arrives we inject a synthetic
+        /// EncryptedSessionKey so the PS SDK's state machine can transition to Opened.
+        /// </para>
+        /// </summary>
+        private void DrainCommandReceive(string commandId, CancellationToken ct)
+        {
+            var cmdFragGuids = new Dictionary<ulong, string>();
+            try
+            {
+                while (!_isClosed && !ct.IsCancellationRequested)
+                {
+                    string endpoint = _connectionInfo.BuildEndpointUri();
+                    string msgId = Guid.NewGuid().ToString().ToUpper();
+                    string soapXml = WsManXml.BuildReceive(endpoint, msgId, _shellId!, commandId, _connectionInfo.ConfigurationName);
+
+                    string response;
+                    try { response = PostSoapAsync(endpoint, soapXml, WsManXml.ActionReceive).GetAwaiter().GetResult(); }
+                    catch when (_isClosed || ct.IsCancellationRequested) { break; }
+                    catch { break; }
+
+                    if (string.IsNullOrWhiteSpace(response)) continue;
+
+                    var parsedStreams = WsManXml.ParseStreams(response)
+                        .OrderBy(stream =>
+                        {
+                            try
+                            {
+                                byte[] bytes = Convert.FromBase64String(stream.Item2);
+                                return IsTerminalCommandState(bytes) ? 1 : 0;
+                            }
+                            catch
+                            {
+                                return 0;
+                            }
+                        })
+                        .ToList();
+
+                    bool commandDone = false;
+                    foreach (var (name, base64Data) in parsedStreams)
+                    {
+                        WinRMTrace.WriteLine($"[WINRM-DBG {T}] CMD-DRAIN stream={name} b64len={base64Data.Length}");
+                        TryInjectPendingEncryptedSessionKey("Command receive active");
+                        try
+                        {
+                            byte[] fb = Convert.FromBase64String(base64Data);
+                            bool observedRealEncryptedSessionKey = false;
+                            string pipelineStateXmlSuffix = string.Empty;
+                            if (fb.Length >= 29)
+                            {
+                                byte flags = fb[16];
+                                bool isStart = (flags & 0x02) != 0;
+                                uint mt = BitConverter.ToUInt32(fb, 25);
+                                string rpidStr = string.Empty;
+                                string pidStr = string.Empty;
+                                if (isStart && fb.Length >= 61)
+                                {
+                                    var rpid = new Guid(fb[29..45]);
+                                    var pid = new Guid(fb[45..61]);
+                                    rpidStr = $" RPID={rpid}";
+                                    pidStr = $" PID={pid}";
+                                    if (_commandPipelineGuid != null &&
+                                        pid != Guid.Empty &&
+                                        !pid.ToString().Equals(_commandPipelineGuid, StringComparison.OrdinalIgnoreCase))
+                                    {
+                                        WinRMTrace.WriteLine($"[WINRM-DBG {T}] CMD-DRAIN pipeline mismatch expected={_commandPipelineGuid} actual={pid}");
+                                    }
+                                }
+
+                                if (mt == 0x00010006)
+                                {
+                                    observedRealEncryptedSessionKey = true;
+                                }
+                                if (mt == 0x00041006) // PIPELINE_STATE terminal → command done
+                                {
+                                    string xml = Encoding.UTF8.GetString(fb, 61, fb.Length - 61).TrimStart('\uFEFF');
+                                    pipelineStateXmlSuffix = $" XML={xml}";
+                                    if (Regex.IsMatch(xml, @"<I32[^>]+>[3-9]<"))
+                                    {
+                                        commandDone = true;
+                                        if (!_keyExchangeInjected)
+                                        {
+                                            WinRMTrace.WriteLine($"[WINRM-DBG {T}] PipelineState=Done observed for command stream");
+                                        }
+                                    }
+                                }
+                                WinRMTrace.WriteLine($"[WINRM-DBG] CMD-DRAIN MsgType=0x{mt:X8} Flags=0x{flags:X2}{rpidStr}{pidStr}{pipelineStateXmlSuffix}");
+                            }
+                            try
+                            {
+                                HandleOutputDataReceived(WsManXml.WrapInDataElement(base64Data, cmdFragGuids));
+                                if (observedRealEncryptedSessionKey)
+                                {
+                                    ObserveRealEncryptedSessionKey("command receive");
+                                }
+                                if (fb.Length >= 29 && BitConverter.ToUInt32(fb, 25) == 0x00041006)
+                                {
+                                    WinRMTrace.WriteLine($"[WINRM-DBG] Session state after command pipeline state dispatch: {GetCurrentSessionState()}");
+                                }
+                            }
+                            catch
+                            {
+                                try
+                                {
+                                    ProcessRawDataCompat(fb, name);
+                                    if (observedRealEncryptedSessionKey)
+                                    {
+                                        ObserveRealEncryptedSessionKey("command receive");
+                                    }
+                                    if (fb.Length >= 29 && BitConverter.ToUInt32(fb, 25) == 0x00041006)
+                                    {
+                                        WinRMTrace.WriteLine($"[WINRM-DBG] Session state after command pipeline state dispatch: {GetCurrentSessionState()}");
+                                    }
+                                }
+                                catch { }
+                            }
+                        }
+                        catch { }
+                    }
+
+                    // Also check for CommandState=Done (no rsp:Stream, just rsp:CommandState)
+                    if (parsedStreams.Count == 0 && response.Contains("CommandState"))
+                        commandDone = true;
+
+                    if (commandDone) break;
+                }
+            }
+            catch { }
+        }
+
+        private static bool IsTerminalCommandState(byte[] fragmentBytes)
+        {
+            if (fragmentBytes.Length < 61)
+            {
+                return false;
+            }
+
+            if (BitConverter.ToUInt32(fragmentBytes, 25) != 0x00041006)
+            {
+                return false;
+            }
+
+            string xml = Encoding.UTF8.GetString(fragmentBytes, 61, fragmentBytes.Length - 61).TrimStart('\uFEFF');
+            return Regex.IsMatch(xml, @"<I32[^>]+>[3-9]<");
+        }
+
+        /// <summary>
+        /// Reader thread: continuously polls the server with WSMan Receive (shell-level) requests
+        /// and feeds returned PSRP lines into the base class via HandleOutputDataReceived.
+        /// RunCommand pipeline messages are handled by DrainCommandReceive running in parallel.
+        /// </summary>
+        private void ProcessReaderThread()
+        {
+            try
+            {
+                var cancellationToken = _readerCts?.Token ?? CancellationToken.None;
+
+                while (!_isClosed && !cancellationToken.IsCancellationRequested)
+                {
+                    try
+                    {
+                        string endpoint = _connectionInfo.BuildEndpointUri();
+                        string msgId = Guid.NewGuid().ToString().ToUpper();
+                        // Always use shell-level Receive (commandId=null) for RunspacePool messages.
+                        // Command-level data (EncryptedSessionKey, PipelineState) is handled by
+                        // DrainCommandReceive running in parallel after each RunCommand.
+                        string soapXml = WsManXml.BuildReceive(endpoint, msgId, _shellId!, null, _connectionInfo.ConfigurationName);
+
+                        WinRMTrace.WriteLine($"[WINRM-DBG] RECEIVE polling...");
+                        string response = PostSoapAsync(endpoint, soapXml, WsManXml.ActionReceive)
+                            .GetAwaiter().GetResult();
+                        WinRMTrace.WriteLine($"[WINRM-DBG] RECEIVE got {response.Length} chars");
+
+                        if (string.IsNullOrWhiteSpace(response))
+                            continue;
+
+                        // Log all stream names and full body when no streams found
+                        bool hasAnyStream = WsManXml.ParseStreams(response).Any();
+                        if (!hasAnyStream)
+                            WinRMTrace.WriteLine($"[WINRM-DBG] RECEIVE no-streams body={response}");
+                        else
+                        {
+                            foreach (var (streamName, _) in WsManXml.ParseStreams(response))
+                                if (streamName != "stdout")
+                                    WinRMTrace.WriteLine($"[WINRM-DBG] RECEIVE non-stdout stream: {streamName}");
+                        }
+
+                        // The WinRM SOAP stream carries raw base64 PSRP fragments.
+                        // Feed raw PSRP bytes into the transport manager so the SDK's normal
+                        // fragment parsing and key-exchange handlers see the same shape of data
+                        // they would get from a native WSMan transport.
+                        foreach (var (name, base64Data) in WsManXml.ParseStreams(response))
+                        {
+                            // Decode and log fragment details for diagnostics
+                            try
+                            {
+                                byte[] fragBytes = Convert.FromBase64String(base64Data);
+                                bool observedRealEncryptedSessionKey = false;
+                                if (fragBytes.Length >= 21)
+                                {
+                                    ulong objId = BitConverter.ToUInt64(fragBytes, 0);
+                                    ulong fragId = BitConverter.ToUInt64(fragBytes, 8);
+                                    byte flags = fragBytes[16];
+                                    bool isStart = (flags & 0x02) != 0;
+                                    bool isEnd = (flags & 0x01) != 0;
+                                    uint blobLen = BitConverter.ToUInt32(fragBytes, 17);
+
+                                    string msgTypeStr = "";
+                                    string rpidStr = "";
+                                    string pidStr = "";
+                                    if (isStart && fragBytes.Length >= 61)
+                                    {
+                                        uint msgType = BitConverter.ToUInt32(fragBytes, 25);
+                                        var rpid = new Guid(fragBytes[29..45]);
+                                        var pid = new Guid(fragBytes[45..61]);
+                                        msgTypeStr = $" MsgType=0x{msgType:X8}";
+                                        rpidStr = $" RPID={rpid}";
+                                        pidStr = $" PID={pid}";
+
+                                        if (msgType == 0x00021005)
+                                        {
+                                            string xml = Encoding.UTF8.GetString(fragBytes, 61, fragBytes.Length - 61).TrimStart('\uFEFF');
+                                            if (Regex.IsMatch(xml, @"<I32[^>]*>2<"))
+                                            {
+                                                WinRMTrace.WriteLine($"[WINRM-DBG {T}] RunspacePool opened without synthetic PublicKeyRequest injection");
+                                            }
+                                        }
+                                        else if (msgType == 0x00010006)
+                                        {
+                                            observedRealEncryptedSessionKey = true;
+                                        }
+                                    }
+                                    WinRMTrace.WriteLine($"[WINRM-DBG {T}] RECV stream={name} b64len={base64Data.Length} fragLen={fragBytes.Length} ObjId={objId} FragId={fragId} Flags=0x{flags:X2}(Start={isStart},End={isEnd}) BlobLen={blobLen}{msgTypeStr}{rpidStr}{pidStr}");
+                                    WinRMTrace.WriteLine($"[WINRM-DBG] RECV FULL_B64={base64Data}");
+                                    ProcessRawDataCompat(fragBytes, name);
+                                    if (observedRealEncryptedSessionKey)
+                                    {
+                                        ObserveRealEncryptedSessionKey("session receive");
+                                    }
+                                }
+                            }
+                            catch (Exception dbgEx)
+                            {
+                                WinRMTrace.WriteLine($"[WINRM-DBG] decode error: {dbgEx.Message}");
+                            }
+                        }
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        break;
+                    }
+                    catch (AggregateException ae) when (ae.InnerException is OperationCanceledException)
+                    {
+                        break;
+                    }
+                    catch (Exception) when (_isClosed)
+                    {
+                        break;
+                    }
+                    catch (Exception ex)
+                    {
+                        if (!_isClosed)
+                        {
+                            HandleTransportError(new PSRemotingTransportException(
+                                $"WinRM Receive failed: {ex.Message}", ex));
+                        }
+                        break;
+                    }
+                }
+            }
+            catch (Exception ex) when (!_isClosed)
+            {
+                HandleTransportError(new PSRemotingTransportException(
+                    $"WinRM reader thread ended unexpectedly: {ex.Message}", ex));
+            }
+        }
+
+        public override void CloseAsync()
+        {
+            // DO NOT set _isClosed or cancel the reader here.
+            // The reader must stay active to receive the PSRP CloseAck from the server.
+            // base.CloseAsync() sends the PSRP close packet via WinRMTextWriter;
+            // CleanupConnection() is called by the base class once CloseAck arrives.
+            base.CloseAsync();
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            if (isDisposing)
+                CleanupConnection();
+
+            base.Dispose(isDisposing);
+        }
+
+        protected override void CleanupConnection()
+        {
+            _isClosed = true;
+            try { _readerCts?.Cancel(); } catch { }
+
+            // Send WSMan Signal(terminate) to end the command, then Delete the shell.
+            if (_shellId != null && _httpClient != null)
+            {
+                try
+                {
+                    string endpoint = _connectionInfo.BuildEndpointUri();
+                    if (_commandId != null)
+                    {
+                        string sigMsgId = Guid.NewGuid().ToString().ToUpper();
+                        string sigSoap = WsManXml.BuildSignal(endpoint, sigMsgId, _shellId, _commandId, _connectionInfo.ConfigurationName);
+                        PostSoapAsync(endpoint, sigSoap, WsManXml.ActionSignal).Wait(3000);
+                    }
+
+                    string msgId = Guid.NewGuid().ToString().ToUpper();
+                    string soapXml = WsManXml.BuildDelete(endpoint, msgId, _shellId, _connectionInfo.ConfigurationName);
+                    PostSoapAsync(endpoint, soapXml, WsManXml.ActionDelete).Wait(5000);
+                }
+                catch { }
+            }
+
+            try { _httpClient?.Dispose(); } catch { }
+            _readerCts?.Dispose();
+            _readerCts = null;
+            _httpClient = null;
+        }
+
+        private void HandleTransportError(PSRemotingTransportException ex)
+        {
+            RaiseErrorHandler(new TransportErrorOccuredEventArgs(
+                ex, TransportMethodEnum.CloseShellOperationEx));
+            CleanupConnection();
+        }
+    }
+}
+

--- a/src/PSHostWinRMServer.cs
+++ b/src/PSHostWinRMServer.cs
@@ -1,0 +1,919 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Management.Automation;
+using System.Linq;
+using System.Net;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+
+namespace AwakeCoding.PSRemoting.PowerShell
+{
+    /// <summary>
+    /// Manages a single remote PowerShell shell session within the WinRM server.
+    /// Wraps a pwsh subprocess and exposes stdin/stdout via thread-safe queues.
+    /// </summary>
+    internal sealed class WinRMShell : IDisposable
+    {
+        public string ShellId { get; }
+
+        private Process? _process;
+        private readonly BlockingCollection<string> _stdoutQueue;
+        private readonly List<string> _deferredStdoutLines = new();
+        private readonly object _stdoutLock = new();
+        private Thread? _stdoutReaderThread;
+        private Thread? _stderrReaderThread;
+        private volatile bool _disposed;
+        public string? CurrentCommandPipelineGuid { get; set; }
+        // Fragment GUID tracker for reconstructing <Data> elements sent to subprocess stdin
+        internal readonly Dictionary<ulong, string> FragmentGuids = new();
+
+        public WinRMShell(string shellId, Process process)
+        {
+            ShellId = shellId ?? throw new ArgumentNullException(nameof(shellId));
+            _process = process ?? throw new ArgumentNullException(nameof(process));
+            _stdoutQueue = new BlockingCollection<string>(1024);
+        }
+
+        /// <summary>
+        /// Starts the background reader threads that drain pwsh stdout/stderr.
+        /// Must be called after the process has been started.
+        /// </summary>
+        public void StartReaders()
+        {
+            _stdoutReaderThread = new Thread(ReadStdout)
+            {
+                Name = $"WinRM Shell {ShellId} stdout reader",
+                IsBackground = true
+            };
+            _stderrReaderThread = new Thread(ReadStderr)
+            {
+                Name = $"WinRM Shell {ShellId} stderr reader",
+                IsBackground = true
+            };
+            _stdoutReaderThread.Start();
+            _stderrReaderThread.Start();
+        }
+
+        /// <summary>
+        /// Write PSRP data to the subprocess stdin.
+        /// </summary>
+        public void WriteToStdin(string data)
+        {
+            if (_disposed || _process == null || _process.HasExited) return;
+            try
+            {
+                _process.StandardInput.WriteLine(data);
+                _process.StandardInput.Flush();
+            }
+            catch { }
+        }
+
+        /// <summary>
+        /// Try to dequeue a line from stdout within the given timeout.
+        /// Returns null if the timeout expires or the shell has closed.
+        /// </summary>
+        public string? TryDequeueStdoutLine(int timeoutMs, Func<string, bool>? predicate = null)
+        {
+            if (_disposed) return null;
+
+            if (TryTakeDeferredLine(predicate, out string? deferredLine))
+                return deferredLine;
+
+            var deadline = DateTime.UtcNow.AddMilliseconds(timeoutMs);
+
+            while (!_disposed)
+            {
+                int remainingMs = timeoutMs < 0
+                    ? Timeout.Infinite
+                    : Math.Max(0, (int)(deadline - DateTime.UtcNow).TotalMilliseconds);
+                if (timeoutMs >= 0 && remainingMs == 0)
+                    return null;
+
+                try
+                {
+                    if (!_stdoutQueue.TryTake(out string? line, remainingMs))
+                        return null;
+
+                    if (predicate == null || predicate(line))
+                        return line;
+
+                    lock (_stdoutLock)
+                    {
+                        _deferredStdoutLines.Add(line);
+                    }
+
+                    if (TryTakeDeferredLine(predicate, out deferredLine))
+                        return deferredLine;
+                }
+                catch (InvalidOperationException)
+                {
+                    return null;
+                }
+            }
+
+            return null;
+        }
+
+        private bool TryTakeDeferredLine(Func<string, bool>? predicate, out string? line)
+        {
+            lock (_stdoutLock)
+            {
+                for (int i = 0; i < _deferredStdoutLines.Count; i++)
+                {
+                    string candidate = _deferredStdoutLines[i];
+                    if (predicate == null || predicate(candidate))
+                    {
+                        _deferredStdoutLines.RemoveAt(i);
+                        line = candidate;
+                        return true;
+                    }
+                }
+            }
+
+            line = null;
+            return false;
+        }
+
+        private void ReadStdout()
+        {
+            try
+            {
+                while (!_disposed && _process != null && !_process.HasExited)
+                {
+                    string? line = _process.StandardOutput.ReadLine();
+                    if (line == null) break;
+                    try { _stdoutQueue.Add(line); }
+                    catch (InvalidOperationException) { break; }
+                }
+            }
+            catch (IOException) { }
+            catch (ObjectDisposedException) { }
+            finally
+            {
+                try { _stdoutQueue.CompleteAdding(); } catch { }
+            }
+        }
+
+        private void ReadStderr()
+        {
+            try
+            {
+                while (!_disposed && _process != null && !_process.HasExited)
+                {
+                    string? line = _process.StandardError.ReadLine();
+                    if (line == null) break;
+                    // Discard stderr - swallowed to avoid blocking
+                }
+            }
+            catch (IOException) { }
+            catch (ObjectDisposedException) { }
+        }
+
+        public void Dispose()
+        {
+            if (_disposed) return;
+            _disposed = true;
+
+            try { _stdoutQueue.CompleteAdding(); } catch { }
+
+            if (_process != null)
+            {
+                try
+                {
+                    if (!_process.HasExited)
+                    {
+                        _process.Kill();
+                        _process.WaitForExit(500);
+                    }
+                }
+                catch { }
+                finally
+                {
+                    _process.Dispose();
+                    _process = null;
+                }
+            }
+
+            _stdoutQueue.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// WinRM server that listens for WSMan/SOAP requests over HTTP using HttpListener.
+    /// Implements the Create/Send/Receive/Delete shell operations to host PowerShell
+    /// remoting sessions without requiring system WinRM to be configured.
+    /// </summary>
+    public class PSHostWinRMServer : PSHostServerBase
+    {
+        private HttpListener? _listener;
+        private readonly ConcurrentDictionary<string, WinRMShell> _shells;
+        private string _httpListenerPrefix = string.Empty;
+        private const string ThreadName = "PSHostWinRMServer Listener";
+
+        /// <summary>URL path for WSMan requests (typically "/wsman").</summary>
+        public string Path { get; private set; }
+
+        /// <summary>Optional credential required for Basic auth. If null, authentication is skipped.</summary>
+        public PSCredential? RequiredCredential { get; private set; }
+
+        /// <summary>Full URI prefix the server is listening on.</summary>
+        public string ListenerPrefix { get; private set; }
+
+        public PSHostWinRMServer(
+            string name,
+            int port,
+            string listenAddress,
+            string path,
+            int maxConnections,
+            int drainTimeout,
+            PSCredential? requiredCredential)
+            : base(name, port, listenAddress, maxConnections, drainTimeout)
+        {
+            Path = path.StartsWith("/") ? path : "/" + path;
+            RequiredCredential = requiredCredential;
+            _shells = new ConcurrentDictionary<string, WinRMShell>(StringComparer.OrdinalIgnoreCase);
+
+            // Build HttpListener prefix
+            string bindHost = DetermineBindHost(listenAddress);
+            _httpListenerPrefix = $"http://{bindHost}:{port}{Path}/";
+            ListenerPrefix = $"http://{listenAddress}:{port}{Path}/";
+        }
+
+        private static string DetermineBindHost(string listenAddress)
+        {
+            if (listenAddress == "127.0.0.1" ||
+                listenAddress.Equals("localhost", StringComparison.OrdinalIgnoreCase) ||
+                listenAddress == "::1")
+                return "localhost";
+
+            if (listenAddress == "0.0.0.0" || listenAddress == "*" || listenAddress == "+")
+                return "+";
+
+            return listenAddress;
+        }
+
+        public override void StartListenerAsync()
+        {
+            if (State == ServerState.Running || State == ServerState.Starting)
+                throw new InvalidOperationException($"Server '{Name}' is already {State}");
+
+            State = ServerState.Starting;
+
+            try
+            {
+                _listener = new HttpListener();
+                _listener.Prefixes.Add(_httpListenerPrefix);
+                _listener.Start();
+
+                _serverInstance.CancellationTokenSource = new CancellationTokenSource();
+
+                _serverInstance.ListenerThread = new Thread(ListenerThreadProc)
+                {
+                    Name = ThreadName,
+                    IsBackground = true
+                };
+                _serverInstance.ListenerThread.Start();
+
+                State = ServerState.Running;
+            }
+            catch (Exception ex)
+            {
+                State = ServerState.Failed;
+                LastError = ex;
+                throw;
+            }
+        }
+
+        public override void StopListenerAsync(bool force)
+        {
+            if (!TryBeginStopping()) return;
+
+            if (State != ServerState.Running && State != ServerState.Starting)
+            {
+                ResetStoppingFlag();
+                return;
+            }
+
+            State = ServerState.Stopping;
+
+            try
+            {
+                _serverInstance.CancellationTokenSource?.Cancel();
+                _listener?.Stop();
+                _listener?.Close();
+
+                if (!force && ConnectionCount > 0)
+                {
+                    var drainStart = DateTime.UtcNow;
+                    var timeout = TimeSpan.FromSeconds(DrainTimeout);
+                    while (ConnectionCount > 0 && (DateTime.UtcNow - drainStart) < timeout)
+                        Thread.Sleep(100);
+                }
+
+                // Kill all active shells
+                foreach (var kv in _shells)
+                {
+                    try { kv.Value.Dispose(); } catch { }
+                }
+                _shells.Clear();
+
+                // Force kill any connection-tracked subprocesses
+                foreach (var connection in _serverInstance.ActiveConnections.Values)
+                {
+                    if (connection.ProcessId.HasValue)
+                    {
+                        try
+                        {
+                            var proc = Process.GetProcessById(connection.ProcessId.Value);
+                            if (!proc.HasExited)
+                            {
+                                proc.Kill();
+                                proc.WaitForExit(ProcessKillWaitTimeoutMs);
+                            }
+                        }
+                        catch { }
+                    }
+                }
+
+                _serverInstance.ActiveConnections.Clear();
+                _serverInstance.ListenerThread?.Join(ListenerThreadJoinTimeoutMs);
+
+                Unregister();
+                State = ServerState.Stopped;
+            }
+            catch (Exception ex)
+            {
+                Unregister();
+                State = ServerState.Failed;
+                LastError = ex;
+                throw;
+            }
+            finally
+            {
+                _serverInstance.CancellationTokenSource?.Dispose();
+                _serverInstance.CancellationTokenSource = null;
+                _listener = null;
+                ResetStoppingFlag();
+            }
+        }
+
+        private void ListenerThreadProc()
+        {
+            var cancellationToken = _serverInstance.CancellationTokenSource?.Token ?? CancellationToken.None;
+
+            try
+            {
+                while (!cancellationToken.IsCancellationRequested && _listener != null && _listener.IsListening)
+                {
+                    try
+                    {
+                        var contextTask = _listener.GetContextAsync();
+                        while (!contextTask.Wait(100))
+                        {
+                            if (cancellationToken.IsCancellationRequested)
+                                return;
+                        }
+
+                        var context = contextTask.Result;
+                        Task.Run(() => HandleRequestAsync(context, cancellationToken));
+                    }
+                    catch (HttpListenerException) when (cancellationToken.IsCancellationRequested)
+                    {
+                        break;
+                    }
+                    catch (ObjectDisposedException)
+                    {
+                        break;
+                    }
+                    catch (Exception)
+                    {
+                        if (cancellationToken.IsCancellationRequested)
+                            break;
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                if (!cancellationToken.IsCancellationRequested)
+                {
+                    State = ServerState.Failed;
+                    LastError = ex;
+                }
+            }
+        }
+
+        private async Task HandleRequestAsync(HttpListenerContext ctx, CancellationToken cancellationToken)
+        {
+            try
+            {
+                // Only accept POST requests
+                if (!ctx.Request.HttpMethod.Equals("POST", StringComparison.OrdinalIgnoreCase))
+                {
+                    SendHttpResponse(ctx, 405, "Method Not Allowed", "text/plain", "Only POST is supported");
+                    return;
+                }
+
+                // Authenticate if a credential is configured
+                if (RequiredCredential != null && !AuthenticateBasic(ctx.Request))
+                {
+                    ctx.Response.StatusCode = 401;
+                    ctx.Response.Headers.Add("WWW-Authenticate", "Basic realm=\"wsman\"");
+                    ctx.Response.ContentLength64 = 0;
+                    ctx.Response.Close();
+                    return;
+                }
+
+                // Read the request body (SOAP XML)
+                string requestBody;
+                using (var reader = new StreamReader(ctx.Request.InputStream, Encoding.UTF8))
+                    requestBody = await reader.ReadToEndAsync().ConfigureAwait(false);
+
+                // Determine the WSMan action
+                string action = ExtractSoapAction(requestBody, ctx.Request);
+
+                string responseXml;
+
+                if (action.EndsWith("/Transfer/Create", StringComparison.OrdinalIgnoreCase) ||
+                    action == WsManXml.ActionCreate)
+                {
+                    responseXml = HandleCreate(requestBody, ctx.Request);
+                }
+                else if (action == WsManXml.ActionSend)
+                {
+                    responseXml = HandleSend(requestBody);
+                }
+                else if (action == WsManXml.ActionReceive)
+                {
+                    responseXml = HandleReceive(requestBody);
+                }
+                else if (action == WsManXml.ActionCommand)
+                {
+                    responseXml = HandleCommand(requestBody);
+                }
+                else if (action == WsManXml.ActionSignal)
+                {
+                    responseXml = HandleSignal(requestBody);
+                }
+                else if (action == WsManXml.ActionDelete ||
+                         action.EndsWith("/Transfer/Delete", StringComparison.OrdinalIgnoreCase))
+                {
+                    responseXml = HandleDelete(requestBody);
+                }
+                else
+                {
+                    SendHttpResponse(ctx, 400, "Bad Request", "text/plain",
+                        $"Unsupported WSMan action: {action}");
+                    return;
+                }
+
+                SendHttpResponse(ctx, 200, "OK", "application/soap+xml;charset=UTF-8", responseXml);
+            }
+            catch (Exception ex)
+            {
+                try
+                {
+                    SendHttpResponse(ctx, 500, "Internal Server Error", "text/plain", ex.Message);
+                }
+                catch { }
+            }
+        }
+
+        private bool AuthenticateBasic(HttpListenerRequest request)
+        {
+            if (RequiredCredential == null) return true;
+
+            string? authHeader = request.Headers["Authorization"];
+            if (string.IsNullOrEmpty(authHeader) || !authHeader.StartsWith("Basic ", StringComparison.OrdinalIgnoreCase))
+                return false;
+
+            try
+            {
+                string encoded = authHeader.Substring(6).Trim();
+                string decoded = Encoding.ASCII.GetString(Convert.FromBase64String(encoded));
+                int sep = decoded.IndexOf(':');
+                if (sep < 0) return false;
+
+                string user = decoded.Substring(0, sep);
+                string pass = decoded.Substring(sep + 1);
+
+                var netCred = RequiredCredential.GetNetworkCredential();
+                return string.Equals(user, netCred.UserName, StringComparison.OrdinalIgnoreCase)
+                    && string.Equals(pass, netCred.Password, StringComparison.Ordinal);
+            }
+            catch { return false; }
+        }
+
+        private static string ExtractSoapAction(string soapXml, HttpListenerRequest request)
+        {
+            // Try SOAPAction HTTP header first
+            string? soapActionHeader = request.Headers["SOAPAction"];
+            if (!string.IsNullOrEmpty(soapActionHeader))
+                return soapActionHeader.Trim('"');
+
+            // Parse from SOAP body
+            try
+            {
+                var doc = XDocument.Parse(soapXml);
+                XNamespace wsa = WsManXml.NsWsa;
+                var actionEl = doc.Descendants(wsa + "Action").GetEnumerator();
+                if (actionEl.MoveNext())
+                    return actionEl.Current.Value;
+            }
+            catch { }
+
+            return string.Empty;
+        }
+
+        private string HandleCreate(string soapXml, HttpListenerRequest request)
+        {
+            string shellId = Guid.NewGuid().ToString().ToUpper();
+
+            // Spawn pwsh subprocess
+            string? executable = PowerShellFinder.GetPowerShellPath();
+            if (executable == null || !File.Exists(executable))
+                throw new InvalidOperationException("PowerShell executable not found on this system");
+
+            var process = new Process();
+            process.StartInfo.FileName = executable;
+            process.StartInfo.Arguments = "-NoLogo -NoProfile -s";
+            process.StartInfo.RedirectStandardInput = true;
+            process.StartInfo.RedirectStandardOutput = true;
+            process.StartInfo.RedirectStandardError = true;
+            process.StartInfo.UseShellExecute = false;
+            process.StartInfo.CreateNoWindow = true;
+            process.Start();
+
+            var shell = new WinRMShell(shellId, process);
+            shell.StartReaders();
+            _shells[shellId] = shell;
+
+            string? creationXml = ParseCreationXmlFromCreateRequest(soapXml);
+            if (!string.IsNullOrWhiteSpace(creationXml))
+            {
+                string dataLine = WsManXml.WrapInDataElement(creationXml, shell.FragmentGuids);
+                shell.WriteToStdin(dataLine);
+            }
+
+            // Track the connection
+            string clientEndpoint = request.RemoteEndPoint?.ToString() ?? "unknown";
+            var connectionDetails = new ConnectionDetails(shellId, clientEndpoint, process.Id);
+            AddConnection(connectionDetails);
+
+            return BuildCreateResponse(shellId);
+        }
+
+        private string HandleSend(string soapXml)
+        {
+            string? shellId = ParseShellIdFromRequest(soapXml);
+            if (shellId == null || !_shells.TryGetValue(shellId, out var shell))
+                throw new InvalidOperationException($"Shell not found: {shellId}");
+
+            // Decode stdin stream data and write to pwsh
+            try
+            {
+                var doc = XDocument.Parse(soapXml);
+                XNamespace rsp = WsManXml.NsRsp;
+
+                foreach (var stream in doc.Descendants(rsp + "Stream"))
+                {
+                    string? name = (string?)stream.Attribute("Name");
+                    if (name != "stdin") continue;
+
+                    string? base64Data = stream.Value;
+                    if (string.IsNullOrEmpty(base64Data)) continue;
+
+                    // The SOAP stream carries base64 binary PSRP fragment.
+                    // Reconstruct the stdio <Data> wrapper that pwsh expects on stdin.
+                    string dataLine = WsManXml.WrapInDataElement(base64Data, shell.FragmentGuids);
+                    shell.WriteToStdin(dataLine);
+                }
+            }
+            catch (Exception ex)
+            {
+                throw new InvalidOperationException($"Failed to process Send request: {ex.Message}", ex);
+            }
+
+            return BuildSendResponse();
+        }
+
+        private string HandleReceive(string soapXml)
+        {
+            string? shellId = ParseShellIdFromRequest(soapXml);
+            if (shellId == null || !_shells.TryGetValue(shellId, out var shell))
+                throw new InvalidOperationException($"Shell not found: {shellId}");
+
+            // Wait up to 500ms for the first stdout line, then return what we have.
+            // The client retries immediately on an empty response; a short timeout keeps
+            // latency low without busy-looping on the server side.
+            string? requestedCommandId = ParseCommandIdFromReceiveRequest(soapXml);
+            string? firstLine = shell.TryDequeueStdoutLine(timeoutMs: 500, predicate: line => MatchesRequestedCommand(line, requestedCommandId, shell.CurrentCommandPipelineGuid));
+
+            var lines = new System.Collections.Generic.List<string>();
+            if (firstLine != null)
+            {
+                lines.Add(firstLine);
+
+                // Drain any additional immediately-available lines (non-blocking)
+                string? extraLine;
+                while ((extraLine = shell.TryDequeueStdoutLine(0, predicate: line => MatchesRequestedCommand(line, requestedCommandId, shell.CurrentCommandPipelineGuid))) != null)
+                    lines.Add(extraLine);
+            }
+
+            return BuildReceiveResponse(shellId, lines);
+        }
+
+        private string HandleDelete(string soapXml)
+        {
+            string? shellId = ParseShellIdFromRequest(soapXml);
+
+            if (shellId != null && _shells.TryRemove(shellId, out var shell))
+            {
+                int? processId = null;
+                try
+                {
+                    // Get process ID before disposing (for tracking cleanup)
+                    var connection = _serverInstance.ActiveConnections.TryGetValue(shellId, out var conn) ? conn : null;
+                    processId = connection?.ProcessId;
+                }
+                catch { }
+
+                shell.Dispose();
+                RemoveConnection(shellId);
+            }
+
+            return BuildDeleteResponse();
+        }
+
+        private string HandleCommand(string soapXml)
+        {
+            // RunCommand: start the PSRP command within the shell. The first PSRP fragment for the
+            // pipeline arrives in <rsp:Arguments>, so replay both the pipeline creation marker and
+            // the initial fragment into pwsh stdin.
+            string? shellId = ParseShellIdFromRequest(soapXml);
+            if (shellId == null || !_shells.TryGetValue(shellId, out var shell))
+                throw new InvalidOperationException($"Shell not found: {shellId}");
+
+            try
+            {
+                var doc = XDocument.Parse(soapXml);
+                XNamespace rsp = WsManXml.NsRsp;
+
+                var commandLine = doc.Descendants(rsp + "CommandLine").FirstOrDefault();
+                string? commandId = (string?)commandLine?.Attribute("CommandId");
+                string? arguments = commandLine?.Element(rsp + "Arguments")?.Value;
+
+                if (!string.IsNullOrWhiteSpace(commandId))
+                {
+                    shell.CurrentCommandPipelineGuid = commandId;
+                    shell.WriteToStdin($"<Command PSGuid='{commandId}' />");
+
+                    if (!string.IsNullOrWhiteSpace(arguments))
+                    {
+                        string dataLine = WsManXml.WrapInDataElement(arguments.Trim(), shell.FragmentGuids);
+                        shell.WriteToStdin(dataLine);
+                    }
+                }
+
+                // Return ShellId as CommandId so subsequent Send/Receive requests can continue
+                // using the single-shell model implemented by this lightweight server.
+                return BuildCommandResponse(shellId);
+            }
+            catch (Exception ex)
+            {
+                throw new InvalidOperationException($"Failed to process Command request: {ex.Message}", ex);
+            }
+        }
+
+        private static string HandleSignal(string soapXml)
+        {
+            // Signal is sent to terminate a running command. We treat it as a no-op
+            // since our server's command lifecycle is tied to the shell (Delete handles cleanup).
+            return BuildSignalResponse();
+        }
+
+        private static string? ParseShellIdFromRequest(string soapXml)
+        {
+            try
+            {
+                var doc = XDocument.Parse(soapXml);
+                XNamespace wsman = WsManXml.NsWsMan;
+
+                foreach (var sel in doc.Descendants(wsman + "Selector"))
+                {
+                    if ((string?)sel.Attribute("Name") == "ShellId")
+                        return sel.Value;
+                }
+            }
+            catch { }
+
+            return null;
+        }
+
+        private static string? ParseCommandIdFromReceiveRequest(string soapXml)
+        {
+            try
+            {
+                var doc = XDocument.Parse(soapXml);
+                XNamespace rsp = WsManXml.NsRsp;
+                return doc.Descendants(rsp + "DesiredStream")
+                    .Select(el => (string?)el.Attribute("CommandId"))
+                    .FirstOrDefault(id => !string.IsNullOrWhiteSpace(id));
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        private static string? ParseCreationXmlFromCreateRequest(string soapXml)
+        {
+            try
+            {
+                var doc = XDocument.Parse(soapXml);
+                var creationElement = doc.Descendants().FirstOrDefault(el =>
+                    string.Equals(el.Name.LocalName, "creationXml", StringComparison.OrdinalIgnoreCase));
+                return string.IsNullOrWhiteSpace(creationElement?.Value) ? null : creationElement.Value.Trim();
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        private static bool MatchesRequestedCommand(string line, string? requestedCommandId, string? currentCommandPipelineGuid)
+        {
+            string? lineCommandId = ExtractPsGuidFromOutputLine(line);
+            if (string.IsNullOrWhiteSpace(requestedCommandId))
+            {
+                return string.IsNullOrWhiteSpace(lineCommandId) ||
+                    string.Equals(lineCommandId, Guid.Empty.ToString(), StringComparison.OrdinalIgnoreCase);
+            }
+
+            string expectedGuid = !string.IsNullOrWhiteSpace(currentCommandPipelineGuid)
+                ? currentCommandPipelineGuid
+                : requestedCommandId;
+            return string.Equals(lineCommandId, expectedGuid, StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static string? ExtractPsGuidFromOutputLine(string line)
+        {
+            int idx = line.IndexOf("PSGuid='", StringComparison.OrdinalIgnoreCase);
+            char quote = '\'';
+            if (idx < 0)
+            {
+                idx = line.IndexOf("PSGuid=\"", StringComparison.OrdinalIgnoreCase);
+                quote = '"';
+            }
+
+            if (idx < 0)
+                return null;
+
+            int start = idx + 8;
+            int end = line.IndexOf(quote, start);
+            return end > start ? line.Substring(start, end - start) : null;
+        }
+
+        private static void SendHttpResponse(
+            HttpListenerContext ctx,
+            int statusCode,
+            string statusDescription,
+            string contentType,
+            string body)
+        {
+            try
+            {
+                byte[] bytes = Encoding.UTF8.GetBytes(body);
+                ctx.Response.StatusCode = statusCode;
+                ctx.Response.StatusDescription = statusDescription;
+                ctx.Response.ContentType = contentType;
+                ctx.Response.ContentLength64 = bytes.Length;
+                ctx.Response.OutputStream.Write(bytes, 0, bytes.Length);
+                ctx.Response.Close();
+            }
+            catch { }
+        }
+
+        // --- SOAP response builders ---
+
+        private static readonly string SoapNs =
+            "xmlns:s=\"http://www.w3.org/2003/05/soap-envelope\"" +
+            " xmlns:wsa=\"http://schemas.xmlsoap.org/ws/2004/08/addressing\"" +
+            " xmlns:wsman=\"http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd\"" +
+            " xmlns:rsp=\"http://schemas.microsoft.com/wbem/wsman/1/windows/shell\"";
+
+        private static string BuildCreateResponse(string shellId)
+        {
+            string msgId = Guid.NewGuid().ToString().ToUpper();
+            return $"<s:Envelope {SoapNs}>" +
+                   "<s:Header>" +
+                   $"<wsa:Action>http://schemas.xmlsoap.org/ws/2004/09/transfer/CreateResponse</wsa:Action>" +
+                   $"<wsa:MessageID>uuid:{msgId}</wsa:MessageID>" +
+                   $"<wsman:SelectorSet><wsman:Selector Name=\"ShellId\">{shellId}</wsman:Selector></wsman:SelectorSet>" +
+                   "</s:Header>" +
+                   "<s:Body>" +
+                   "<rsp:Shell>" +
+                   $"<rsp:ShellId>{shellId}</rsp:ShellId>" +
+                   "<rsp:InputStreams>stdin</rsp:InputStreams>" +
+                   "<rsp:OutputStreams>stdout stderr</rsp:OutputStreams>" +
+                   "</rsp:Shell>" +
+                   "</s:Body>" +
+                   "</s:Envelope>";
+        }
+
+        private static string BuildSendResponse()
+        {
+            string msgId = Guid.NewGuid().ToString().ToUpper();
+            return $"<s:Envelope {SoapNs}>" +
+                   "<s:Header>" +
+                   $"<wsa:Action>http://schemas.microsoft.com/wbem/wsman/1/windows/shell/SendResponse</wsa:Action>" +
+                   $"<wsa:MessageID>uuid:{msgId}</wsa:MessageID>" +
+                   "</s:Header>" +
+                   "<s:Body><rsp:SendResponse/></s:Body>" +
+                   "</s:Envelope>";
+        }
+
+        private static string BuildReceiveResponse(string shellId, System.Collections.Generic.List<string> stdoutLines)
+        {
+            string msgId = Guid.NewGuid().ToString().ToUpper();
+            var sb = new StringBuilder();
+            sb.Append($"<s:Envelope {SoapNs}>");
+            sb.Append("<s:Header>");
+            sb.Append($"<wsa:Action>http://schemas.microsoft.com/wbem/wsman/1/windows/shell/ReceiveResponse</wsa:Action>");
+            sb.Append($"<wsa:MessageID>uuid:{msgId}</wsa:MessageID>");
+            sb.Append("</s:Header>");
+            sb.Append("<s:Body><rsp:ReceiveResponse>");
+
+            foreach (string line in stdoutLines)
+            {
+                // pwsh stdout emits: <Data Stream='Default' PSGuid='GUID'>BASE64</Data>
+                // WinRM SOAP streams carry only the BASE64 binary fragment.
+                string base64 = WsManXml.ExtractBase64FromDataElement(line);
+                sb.Append($"<rsp:Stream Name=\"stdout\" CommandId=\"{shellId}\">{base64}</rsp:Stream>");
+            }
+
+            sb.Append("</rsp:ReceiveResponse></s:Body></s:Envelope>");
+            return sb.ToString();
+        }
+
+        private static string BuildDeleteResponse()
+        {
+            string msgId = Guid.NewGuid().ToString().ToUpper();
+            return $"<s:Envelope {SoapNs}>" +
+                   "<s:Header>" +
+                   $"<wsa:Action>http://schemas.xmlsoap.org/ws/2004/09/transfer/DeleteResponse</wsa:Action>" +
+                   $"<wsa:MessageID>uuid:{msgId}</wsa:MessageID>" +
+                   "</s:Header>" +
+                   "<s:Body/>" +
+                   "</s:Envelope>";
+        }
+
+        private static string BuildCommandResponse(string commandId)
+        {
+            string msgId = Guid.NewGuid().ToString().ToUpper();
+            return $"<s:Envelope {SoapNs}>" +
+                   "<s:Header>" +
+                   $"<wsa:Action>http://schemas.microsoft.com/wbem/wsman/1/windows/shell/CommandResponse</wsa:Action>" +
+                   $"<wsa:MessageID>uuid:{msgId}</wsa:MessageID>" +
+                   "</s:Header>" +
+                   "<s:Body>" +
+                   $"<rsp:CommandResponse><rsp:CommandId>{commandId}</rsp:CommandId></rsp:CommandResponse>" +
+                   "</s:Body>" +
+                   "</s:Envelope>";
+        }
+
+        private static string BuildSignalResponse()
+        {
+            string msgId = Guid.NewGuid().ToString().ToUpper();
+            return $"<s:Envelope {SoapNs}>" +
+                   "<s:Header>" +
+                   $"<wsa:Action>http://schemas.microsoft.com/wbem/wsman/1/windows/shell/SignalResponse</wsa:Action>" +
+                   $"<wsa:MessageID>uuid:{msgId}</wsa:MessageID>" +
+                   "</s:Header>" +
+                   "<s:Body/>" +
+                   "</s:Envelope>";
+        }
+
+        protected override void AcceptConnectionAsync()
+        {
+            throw new NotImplementedException("WinRM connections are handled asynchronously via HandleRequestAsync");
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _listener?.Stop();
+                _listener?.Close();
+                foreach (var kv in _shells)
+                    try { kv.Value.Dispose(); } catch { }
+                _shells.Clear();
+            }
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/src/WinRMSspiAuth.cs
+++ b/src/WinRMSspiAuth.cs
@@ -1,0 +1,648 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.IO;
+using System.Management.Automation;
+using System.Net;
+using System.Runtime.InteropServices;
+
+namespace AwakeCoding.PSRemoting.PowerShell
+{
+    internal interface IWinRMNegotiateAuthContext : IDisposable
+    {
+        string HttpAuthLabel { get; }
+        bool Complete { get; }
+        byte[]? Step(byte[]? incomingToken);
+    }
+
+    internal static class WinRMSspiProviderFactory
+    {
+        private static readonly object s_syncRoot = new();
+        private static WinRMSspiProvider? s_devolutionsProvider;
+        private static WinRMSspiProvider? s_windowsProvider;
+
+        public static IWinRMNegotiateAuthContext CreateContext(WinRMClientInfo connectionInfo, Uri endpoint)
+        {
+            if (connectionInfo == null) throw new ArgumentNullException(nameof(connectionInfo));
+            if (endpoint == null) throw new ArgumentNullException(nameof(endpoint));
+            if (connectionInfo.Credential == null && !connectionInfo.UseImplicitCredential)
+            {
+                throw new InvalidOperationException("WinRM Negotiate/Kerberos requires explicit credentials unless -UseImplicitCredential is specified.");
+            }
+
+            WinRMSspiProvider provider = GetDefaultProvider();
+            string package = connectionInfo.Authentication == WinRMAuthenticationMechanism.Kerberos ? "Kerberos" : "Negotiate";
+            string headerLabel = connectionInfo.Authentication == WinRMAuthenticationMechanism.Kerberos ? "Kerberos" : "Negotiate";
+            string targetName = $"host/{endpoint.Host}";
+
+            return new WinRMSspiAuthContext(provider, package, headerLabel, targetName, connectionInfo.Credential);
+        }
+
+        private static WinRMSspiProvider GetDefaultProvider()
+        {
+            try
+            {
+                return GetOrLoadDevolutionsProvider();
+            }
+            catch (Exception ex) when (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                WinRMTrace.WriteLine($"[WINRM-DBG] Devolutions.Sspi unavailable, falling back to Windows SSPI: {ex.Message}");
+                return GetOrLoadWindowsProvider();
+            }
+        }
+
+        private static WinRMSspiProvider GetOrLoadDevolutionsProvider()
+        {
+            lock (s_syncRoot)
+            {
+                s_devolutionsProvider ??= WinRMSspiProvider.Load(
+                    "Devolutions.Sspi",
+                    GetDevolutionsLibraryCandidates(),
+                    required: true);
+
+                return s_devolutionsProvider;
+            }
+        }
+
+        private static WinRMSspiProvider GetOrLoadWindowsProvider()
+        {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                throw new PlatformNotSupportedException("The Windows SSPI backend is only available on Windows.");
+            }
+
+            lock (s_syncRoot)
+            {
+                s_windowsProvider ??= WinRMSspiProvider.Load(
+                    "Windows SSPI",
+                    new[] { "Secur32.dll" },
+                    required: true);
+
+                return s_windowsProvider;
+            }
+        }
+
+        private static IEnumerable<string> GetDevolutionsLibraryCandidates()
+        {
+            string assemblyDirectory = Path.GetDirectoryName(typeof(WinRMSspiProviderFactory).Assembly.Location) ?? string.Empty;
+            string osName;
+            string extension;
+            string prefix = string.Empty;
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                osName = "win";
+                extension = "dll";
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                osName = "osx";
+                extension = "dylib";
+                prefix = "lib";
+            }
+            else
+            {
+                osName = "linux";
+                extension = "so";
+                prefix = "lib";
+            }
+
+            string architecture = RuntimeInformation.ProcessArchitecture.ToString().ToLowerInvariant();
+            string fileName = $"{prefix}DevolutionsSspi.{extension}";
+
+            yield return Path.Combine(assemblyDirectory, "runtimes", $"{osName}-{architecture}", "native", fileName);
+            yield return Path.Combine(assemblyDirectory, fileName);
+            yield return fileName;
+            yield return "DevolutionsSspi";
+        }
+    }
+
+    internal sealed class WinRMSspiAuthContext : IWinRMNegotiateAuthContext
+    {
+        private readonly WinRMSspiProvider _provider;
+        private readonly WinRMSspiCredentialHandle _credential;
+        private readonly string _targetName;
+        private WinRMSspiContextHandle? _context;
+
+        public string HttpAuthLabel { get; }
+        public bool Complete { get; private set; }
+
+        public WinRMSspiAuthContext(
+            WinRMSspiProvider provider,
+            string package,
+            string httpAuthLabel,
+            string targetName,
+            PSCredential? credential)
+        {
+            _provider = provider ?? throw new ArgumentNullException(nameof(provider));
+            _credential = _provider.AcquireCredentials(package, credential);
+            _targetName = targetName ?? throw new ArgumentNullException(nameof(targetName));
+            HttpAuthLabel = httpAuthLabel ?? throw new ArgumentNullException(nameof(httpAuthLabel));
+        }
+
+        public byte[]? Step(byte[]? incomingToken)
+        {
+            var result = _provider.InitializeSecurityContext(
+                _credential,
+                _context,
+                _targetName,
+                CreateContextFlags(),
+                incomingToken);
+
+            _context = result.Context;
+            Complete = !result.MoreNeeded;
+            return result.OutputToken;
+        }
+
+        public void Dispose()
+        {
+            _context?.Dispose();
+            _credential.Dispose();
+        }
+
+        private static InitiatorContextRequestFlags CreateContextFlags()
+        {
+            return InitiatorContextRequestFlags.ISC_REQ_CONNECTION
+                | InitiatorContextRequestFlags.ISC_REQ_MUTUAL_AUTH
+                | InitiatorContextRequestFlags.ISC_REQ_REPLAY_DETECT
+                | InitiatorContextRequestFlags.ISC_REQ_SEQUENCE_DETECT
+                | InitiatorContextRequestFlags.ISC_REQ_CONFIDENTIALITY
+                | InitiatorContextRequestFlags.ISC_REQ_INTEGRITY;
+        }
+    }
+
+    internal sealed class WinRMSspiProvider : IDisposable
+    {
+        private const int ContinueNeeded = unchecked((int)0x00090312);
+        private readonly IntPtr _module;
+        private readonly Dictionary<string, Delegate> _delegateCache = new(StringComparer.Ordinal);
+
+        private WinRMSspiProvider(IntPtr module)
+        {
+            _module = module;
+        }
+
+        public static WinRMSspiProvider Load(string displayName, IEnumerable<string> candidates, bool required)
+        {
+            List<string> attempted = new();
+            foreach (string candidate in candidates)
+            {
+                attempted.Add(candidate);
+                if (NativeLibrary.TryLoad(candidate, out IntPtr module))
+                {
+                    return new WinRMSspiProvider(module);
+                }
+            }
+
+            if (!required)
+            {
+                return new WinRMSspiProvider(IntPtr.Zero);
+            }
+
+            throw new DllNotFoundException(
+                $"Failed to find required {displayName} library. Searched: '{string.Join("', '", attempted)}'. " +
+                "Ensure the module's runtimes assets are present.");
+        }
+
+        public WinRMSspiCredentialHandle AcquireCredentials(string package, PSCredential? credential)
+        {
+            string? username = credential?.UserName;
+            string? domain = null;
+            string? password = credential?.GetNetworkCredential().Password;
+
+            if (!string.IsNullOrEmpty(username) && username.Contains('\\'))
+            {
+                string[] parts = username.Split('\\', 2);
+                domain = parts[0];
+                username = parts[1];
+            }
+
+            IntPtr userPtr = IntPtr.Zero;
+            IntPtr domainPtr = IntPtr.Zero;
+            IntPtr passwordPtr = IntPtr.Zero;
+            IntPtr authDataPtr = IntPtr.Zero;
+
+            try
+            {
+                if (username != null || domain != null || password != null)
+                {
+                    userPtr = username != null ? Marshal.StringToHGlobalUni(username) : IntPtr.Zero;
+                    domainPtr = domain != null ? Marshal.StringToHGlobalUni(domain) : IntPtr.Zero;
+                    passwordPtr = password != null ? Marshal.StringToHGlobalUni(password) : IntPtr.Zero;
+                    authDataPtr = Marshal.AllocHGlobal(Marshal.SizeOf<SEC_WINNT_AUTH_IDENTITY_W>());
+
+                    var authData = new SEC_WINNT_AUTH_IDENTITY_W
+                    {
+                        User = userPtr,
+                        UserLength = (uint)(username?.Length ?? 0),
+                        Domain = domainPtr,
+                        DomainLength = (uint)(domain?.Length ?? 0),
+                        Password = passwordPtr,
+                        PasswordLength = (uint)(password?.Length ?? 0),
+                        Flags = WinNTAuthIdentityFlags.SEC_WINNT_AUTH_IDENTITY_UNICODE
+                    };
+
+                    Marshal.StructureToPtr(authData, authDataPtr, false);
+                }
+
+                var handle = new WinRMSspiCredentialHandle(this);
+                int status = GetDelegate<AcquireCredentialsHandleDelegate>("AcquireCredentialsHandleW")(
+                    null,
+                    package,
+                    (uint)CredentialUse.SECPKG_CRED_OUTBOUND,
+                    IntPtr.Zero,
+                    authDataPtr,
+                    IntPtr.Zero,
+                    IntPtr.Zero,
+                    handle.Pointer,
+                    out _);
+
+                if (status != 0)
+                {
+                    handle.Dispose();
+                    throw CreateSspiException(status, "AcquireCredentialsHandle");
+                }
+
+                handle.MarkOwned();
+                return handle;
+            }
+            finally
+            {
+                if (authDataPtr != IntPtr.Zero)
+                {
+                    Marshal.DestroyStructure<SEC_WINNT_AUTH_IDENTITY_W>(authDataPtr);
+                    Marshal.FreeHGlobal(authDataPtr);
+                }
+
+                if (userPtr != IntPtr.Zero) Marshal.FreeHGlobal(userPtr);
+                if (domainPtr != IntPtr.Zero) Marshal.FreeHGlobal(domainPtr);
+                if (passwordPtr != IntPtr.Zero) Marshal.FreeHGlobal(passwordPtr);
+            }
+        }
+
+        public WinRMSspiContextResult InitializeSecurityContext(
+            WinRMSspiCredentialHandle credential,
+            WinRMSspiContextHandle? context,
+            string targetName,
+            InitiatorContextRequestFlags flags,
+            byte[]? inputToken)
+        {
+            flags |= InitiatorContextRequestFlags.ISC_REQ_ALLOCATE_MEMORY;
+
+            IntPtr inputTokenPtr = IntPtr.Zero;
+            IntPtr inputBufferPtr = IntPtr.Zero;
+            IntPtr inputBufferDescPtr = IntPtr.Zero;
+            IntPtr outputBufferPtr = IntPtr.Zero;
+            IntPtr outputBufferDescPtr = IntPtr.Zero;
+            WinRMSspiContextHandle? outputContext = null;
+
+            try
+            {
+                if (inputToken != null && inputToken.Length > 0)
+                {
+                    inputTokenPtr = Marshal.AllocHGlobal(inputToken.Length);
+                    Marshal.Copy(inputToken, 0, inputTokenPtr, inputToken.Length);
+
+                    inputBufferPtr = Marshal.AllocHGlobal(Marshal.SizeOf<SecBuffer>());
+                    Marshal.StructureToPtr(new SecBuffer
+                    {
+                        cbBuffer = (uint)inputToken.Length,
+                        BufferType = (uint)SecBufferType.SECBUFFER_TOKEN,
+                        pvBuffer = inputTokenPtr
+                    }, inputBufferPtr, false);
+
+                    inputBufferDescPtr = Marshal.AllocHGlobal(Marshal.SizeOf<SecBufferDesc>());
+                    Marshal.StructureToPtr(new SecBufferDesc
+                    {
+                        ulVersion = 0,
+                        cBuffers = 1,
+                        pBuffers = inputBufferPtr
+                    }, inputBufferDescPtr, false);
+                }
+
+                outputBufferPtr = Marshal.AllocHGlobal(Marshal.SizeOf<SecBuffer>());
+                Marshal.StructureToPtr(new SecBuffer
+                {
+                    cbBuffer = 0,
+                    BufferType = (uint)SecBufferType.SECBUFFER_TOKEN,
+                    pvBuffer = IntPtr.Zero
+                }, outputBufferPtr, false);
+
+                outputBufferDescPtr = Marshal.AllocHGlobal(Marshal.SizeOf<SecBufferDesc>());
+                Marshal.StructureToPtr(new SecBufferDesc
+                {
+                    ulVersion = 0,
+                    cBuffers = 1,
+                    pBuffers = outputBufferPtr
+                }, outputBufferDescPtr, false);
+
+                outputContext = context ?? new WinRMSspiContextHandle(this);
+                IntPtr inputContext = context?.Pointer ?? IntPtr.Zero;
+                IntPtr newContext = outputContext.Pointer;
+
+                int status = GetDelegate<InitializeSecurityContextDelegate>("InitializeSecurityContextW")(
+                    credential.Pointer,
+                    inputContext,
+                    targetName,
+                    flags,
+                    0,
+                    (uint)TargetDataRep.SECURITY_NATIVE_DREP,
+                    inputBufferDescPtr,
+                    0,
+                    newContext,
+                    outputBufferDescPtr,
+                    out _,
+                    out _);
+
+                if (status != 0 && status != ContinueNeeded)
+                {
+                    if (context == null)
+                    {
+                        outputContext.Dispose();
+                    }
+
+                    throw CreateSspiException(status, "InitializeSecurityContext");
+                }
+
+                outputContext.MarkOwned();
+                var outputBuffer = Marshal.PtrToStructure<SecBuffer>(outputBufferPtr);
+                byte[]? outputToken = null;
+                if (outputBuffer.cbBuffer > 0 && outputBuffer.pvBuffer != IntPtr.Zero)
+                {
+                    outputToken = new byte[outputBuffer.cbBuffer];
+                    Marshal.Copy(outputBuffer.pvBuffer, outputToken, 0, outputToken.Length);
+                    GetDelegate<FreeContextBufferDelegate>("FreeContextBuffer")(outputBuffer.pvBuffer);
+                }
+
+                return new WinRMSspiContextResult(outputContext, outputToken, status == ContinueNeeded);
+            }
+            finally
+            {
+                if (inputBufferDescPtr != IntPtr.Zero)
+                {
+                    Marshal.DestroyStructure<SecBufferDesc>(inputBufferDescPtr);
+                    Marshal.FreeHGlobal(inputBufferDescPtr);
+                }
+
+                if (inputBufferPtr != IntPtr.Zero)
+                {
+                    Marshal.DestroyStructure<SecBuffer>(inputBufferPtr);
+                    Marshal.FreeHGlobal(inputBufferPtr);
+                }
+
+                if (inputTokenPtr != IntPtr.Zero)
+                {
+                    Marshal.FreeHGlobal(inputTokenPtr);
+                }
+
+                if (outputBufferDescPtr != IntPtr.Zero)
+                {
+                    Marshal.DestroyStructure<SecBufferDesc>(outputBufferDescPtr);
+                    Marshal.FreeHGlobal(outputBufferDescPtr);
+                }
+
+                if (outputBufferPtr != IntPtr.Zero)
+                {
+                    Marshal.DestroyStructure<SecBuffer>(outputBufferPtr);
+                    Marshal.FreeHGlobal(outputBufferPtr);
+                }
+            }
+        }
+
+        public void ReleaseCredential(IntPtr handlePointer)
+        {
+            GetDelegate<FreeCredentialsHandleDelegate>("FreeCredentialsHandle")(handlePointer);
+        }
+
+        public void ReleaseContext(IntPtr handlePointer)
+        {
+            GetDelegate<DeleteSecurityContextDelegate>("DeleteSecurityContext")(handlePointer);
+        }
+
+        public void Dispose()
+        {
+            if (_module != IntPtr.Zero)
+            {
+                NativeLibrary.Free(_module);
+            }
+        }
+
+        private T GetDelegate<T>(string exportName)
+            where T : Delegate
+        {
+            if (_module == IntPtr.Zero)
+            {
+                throw new InvalidOperationException("The SSPI provider library is not loaded.");
+            }
+
+            if (!_delegateCache.TryGetValue(exportName, out Delegate? value))
+            {
+                IntPtr export = NativeLibrary.GetExport(_module, exportName);
+                value = Marshal.GetDelegateForFunctionPointer(export, typeof(T));
+                _delegateCache[exportName] = value;
+            }
+
+            return (T)value;
+        }
+
+        private static Exception CreateSspiException(int status, string operation)
+        {
+            return new InvalidOperationException(
+                $"{operation} failed ({new Win32Exception(status).Message}, 0x{status:X8}).");
+        }
+
+        [UnmanagedFunctionPointer(CallingConvention.Winapi, CharSet = CharSet.Unicode)]
+        private delegate int AcquireCredentialsHandleDelegate(
+            string? principal,
+            string package,
+            uint credentialUse,
+            IntPtr logonId,
+            IntPtr authData,
+            IntPtr getKeyFn,
+            IntPtr getKeyArgument,
+            IntPtr credentialHandle,
+            out SECURITY_INTEGER expiry);
+
+        [UnmanagedFunctionPointer(CallingConvention.Winapi, CharSet = CharSet.Unicode)]
+        private delegate int InitializeSecurityContextDelegate(
+            IntPtr credentialHandle,
+            IntPtr contextHandle,
+            string targetName,
+            InitiatorContextRequestFlags contextReq,
+            uint reserved1,
+            uint targetDataRep,
+            IntPtr input,
+            uint reserved2,
+            IntPtr newContext,
+            IntPtr output,
+            out InitiatorContextReturnFlags contextAttributes,
+            out SECURITY_INTEGER expiry);
+
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
+        private delegate int FreeCredentialsHandleDelegate(IntPtr credentialHandle);
+
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
+        private delegate int DeleteSecurityContextDelegate(IntPtr contextHandle);
+
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
+        private delegate int FreeContextBufferDelegate(IntPtr contextBuffer);
+    }
+
+    internal sealed class WinRMSspiContextResult
+    {
+        public WinRMSspiContextResult(WinRMSspiContextHandle context, byte[]? outputToken, bool moreNeeded)
+        {
+            Context = context;
+            OutputToken = outputToken;
+            MoreNeeded = moreNeeded;
+        }
+
+        public WinRMSspiContextHandle Context { get; }
+        public byte[]? OutputToken { get; }
+        public bool MoreNeeded { get; }
+    }
+
+    internal sealed class WinRMSspiCredentialHandle : IDisposable
+    {
+        private readonly WinRMSspiProvider _provider;
+        private bool _ownsHandle;
+
+        public WinRMSspiCredentialHandle(WinRMSspiProvider provider)
+        {
+            _provider = provider;
+            Pointer = Marshal.AllocHGlobal(Marshal.SizeOf<SecHandle>());
+            Marshal.StructureToPtr(new SecHandle(), Pointer, false);
+        }
+
+        public IntPtr Pointer { get; private set; }
+
+        public void MarkOwned() => _ownsHandle = true;
+
+        public void Dispose()
+        {
+            if (Pointer != IntPtr.Zero)
+            {
+                if (_ownsHandle)
+                {
+                    _provider.ReleaseCredential(Pointer);
+                }
+
+                Marshal.DestroyStructure<SecHandle>(Pointer);
+                Marshal.FreeHGlobal(Pointer);
+                Pointer = IntPtr.Zero;
+            }
+        }
+    }
+
+    internal sealed class WinRMSspiContextHandle : IDisposable
+    {
+        private readonly WinRMSspiProvider _provider;
+        private bool _ownsHandle;
+
+        public WinRMSspiContextHandle(WinRMSspiProvider provider)
+        {
+            _provider = provider;
+            Pointer = Marshal.AllocHGlobal(Marshal.SizeOf<SecHandle>());
+            Marshal.StructureToPtr(new SecHandle(), Pointer, false);
+        }
+
+        public IntPtr Pointer { get; private set; }
+
+        public void MarkOwned() => _ownsHandle = true;
+
+        public void Dispose()
+        {
+            if (Pointer != IntPtr.Zero)
+            {
+                if (_ownsHandle)
+                {
+                    _provider.ReleaseContext(Pointer);
+                }
+
+                Marshal.DestroyStructure<SecHandle>(Pointer);
+                Marshal.FreeHGlobal(Pointer);
+                Pointer = IntPtr.Zero;
+            }
+        }
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct SEC_WINNT_AUTH_IDENTITY_W
+    {
+        public IntPtr User;
+        public uint UserLength;
+        public IntPtr Domain;
+        public uint DomainLength;
+        public IntPtr Password;
+        public uint PasswordLength;
+        public WinNTAuthIdentityFlags Flags;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct SECURITY_INTEGER
+    {
+        public uint LowPart;
+        public int HighPart;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct SecBufferDesc
+    {
+        public uint ulVersion;
+        public uint cBuffers;
+        public IntPtr pBuffers;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct SecBuffer
+    {
+        public uint cbBuffer;
+        public uint BufferType;
+        public IntPtr pvBuffer;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct SecHandle
+    {
+        public IntPtr dwLower;
+        public IntPtr dwUpper;
+    }
+
+    internal enum CredentialUse : uint
+    {
+        SECPKG_CRED_OUTBOUND = 0x00000002
+    }
+
+    [Flags]
+    internal enum InitiatorContextRequestFlags : uint
+    {
+        ISC_REQ_MUTUAL_AUTH = 0x00000002,
+        ISC_REQ_REPLAY_DETECT = 0x00000004,
+        ISC_REQ_SEQUENCE_DETECT = 0x00000008,
+        ISC_REQ_CONFIDENTIALITY = 0x00000010,
+        ISC_REQ_ALLOCATE_MEMORY = 0x00000100,
+        ISC_REQ_CONNECTION = 0x00000800,
+        ISC_REQ_INTEGRITY = 0x00010000
+    }
+
+    [Flags]
+    internal enum InitiatorContextReturnFlags : uint
+    {
+        ISC_RET_MUTUAL_AUTH = 0x00000002
+    }
+
+    internal enum TargetDataRep : uint
+    {
+        SECURITY_NATIVE_DREP = 0x00000010
+    }
+
+    internal enum SecBufferType : uint
+    {
+        SECBUFFER_TOKEN = 2
+    }
+
+    internal enum WinNTAuthIdentityFlags : uint
+    {
+        SEC_WINNT_AUTH_IDENTITY_UNICODE = 2
+    }
+}

--- a/tests/AwakeCoding.PSRemoting.Tests.ps1
+++ b/tests/AwakeCoding.PSRemoting.Tests.ps1
@@ -1303,33 +1303,22 @@ Describe 'End-to-End Client Transport Tests' {
             }
         }
 
-        It 'Executes arithmetic over WinRM transport' {
+        It 'Executes commands over WinRM transport' {
             $session = New-TestWinRMSession -Port $script:WinRMPort -Credential $script:WinRMCredential -OpenTimeout $script:WinRMOpenTimeout
             try {
-                $result = Invoke-TestCommandWithTimeout -Session $session -ScriptBlock { 6 + 7 } -TimeoutSeconds $script:WinRMCommandTimeoutSeconds
-                $result | Should -Be 13
-            }
-            finally {
-                Remove-PSHostSessionSafely -Session $session
-            }
-        }
+                $result = Invoke-TestCommandWithTimeout -Session $session -ArgumentList 5 -TimeoutSeconds $script:WinRMCommandTimeoutSeconds -ScriptBlock {
+                    param($x)
 
-        It 'Retrieves PSVersionTable over WinRM' {
-            $session = New-TestWinRMSession -Port $script:WinRMPort -Credential $script:WinRMCredential -OpenTimeout $script:WinRMOpenTimeout
-            try {
-                $version = Invoke-TestCommandWithTimeout -Session $session -ScriptBlock { $PSVersionTable.PSVersion.Major } -TimeoutSeconds $script:WinRMCommandTimeoutSeconds
-                $version | Should -BeGreaterOrEqual 7
-            }
-            finally {
-                Remove-PSHostSessionSafely -Session $session
-            }
-        }
+                    [pscustomobject]@{
+                        Sum = 6 + 7
+                        MajorVersion = $PSVersionTable.PSVersion.Major
+                        Triple = $x * 3
+                    }
+                }
 
-        It 'Passes arguments over WinRM' {
-            $session = New-TestWinRMSession -Port $script:WinRMPort -Credential $script:WinRMCredential -OpenTimeout $script:WinRMOpenTimeout
-            try {
-                $result = Invoke-TestCommandWithTimeout -Session $session -ScriptBlock { param($x) $x * 3 } -ArgumentList 5 -TimeoutSeconds $script:WinRMCommandTimeoutSeconds
-                $result | Should -Be 15
+                $result.Sum | Should -Be 13
+                $result.MajorVersion | Should -BeGreaterOrEqual 7
+                $result.Triple | Should -Be 15
             }
             finally {
                 Remove-PSHostSessionSafely -Session $session

--- a/tests/AwakeCoding.PSRemoting.Tests.ps1
+++ b/tests/AwakeCoding.PSRemoting.Tests.ps1
@@ -583,7 +583,7 @@ Describe 'Update-PSHostProcessEnvironment Cmdlet Tests' {
                 $result.Mode | Should -Be 'Explicit'
                 $result.AppliedCount | Should -Be 1
 
-                $session = Connect-PSHostProcess -Id $script:UpdateHostPID
+                $session = Connect-PSHostProcess -Id $script:UpdateHostPID -OpenTimeout $script:UpdateCmdletOpenTimeout
                 try {
                     $remoteValue = Invoke-Command -Session $session -ScriptBlock {
                         param($name)
@@ -613,7 +613,7 @@ Describe 'Update-PSHostProcessEnvironment Cmdlet Tests' {
             $removeResult.Mode | Should -Be 'Explicit'
             $removeResult.AppliedCount | Should -Be 1
 
-            $session = Connect-PSHostProcess -Id $script:UpdateHostPID
+            $session = Connect-PSHostProcess -Id $script:UpdateHostPID -OpenTimeout $script:UpdateCmdletOpenTimeout
             try {
                 $remoteValue = Invoke-Command -Session $session -ScriptBlock {
                     param($name)

--- a/tests/AwakeCoding.PSRemoting.Tests.ps1
+++ b/tests/AwakeCoding.PSRemoting.Tests.ps1
@@ -1219,6 +1219,7 @@ Describe 'End-to-End Client Transport Tests' {
             $script:WinRMPort = Get-Random -Minimum 22000 -Maximum 24000
             $script:WinRMServer = Start-PSHostServer -TransportType WinRM -Port $script:WinRMPort -Name 'WinRME2ETest'
             $script:WinRMCredential = New-TestPSCredential -UserName 'winrm-user' -Password 'winrm-pass'
+            $script:WinRMOpenTimeout = 60000
         }
 
         AfterAll {
@@ -1226,7 +1227,7 @@ Describe 'End-to-End Client Transport Tests' {
         }
 
         It 'Connects to WinRM server and creates session' {
-            $session = New-PSHostSession -ComputerName 'localhost' -Port $script:WinRMPort -Credential $script:WinRMCredential
+            $session = New-PSHostSession -ComputerName 'localhost' -Port $script:WinRMPort -Credential $script:WinRMCredential -OpenTimeout $script:WinRMOpenTimeout
             try {
                 $session | Should -Not -BeNullOrEmpty
                 $session.State | Should -Be 'Opened'
@@ -1237,7 +1238,7 @@ Describe 'End-to-End Client Transport Tests' {
         }
 
         It 'Executes arithmetic over WinRM transport' {
-            $session = New-PSHostSession -ComputerName 'localhost' -Port $script:WinRMPort -Credential $script:WinRMCredential
+            $session = New-PSHostSession -ComputerName 'localhost' -Port $script:WinRMPort -Credential $script:WinRMCredential -OpenTimeout $script:WinRMOpenTimeout
             try {
                 $result = Invoke-Command -Session $session -ScriptBlock { 6 + 7 } -ErrorAction Stop
                 $result | Should -Be 13
@@ -1248,7 +1249,7 @@ Describe 'End-to-End Client Transport Tests' {
         }
 
         It 'Retrieves PSVersionTable over WinRM' {
-            $session = New-PSHostSession -ComputerName 'localhost' -Port $script:WinRMPort -Credential $script:WinRMCredential
+            $session = New-PSHostSession -ComputerName 'localhost' -Port $script:WinRMPort -Credential $script:WinRMCredential -OpenTimeout $script:WinRMOpenTimeout
             try {
                 $version = Invoke-Command -Session $session -ScriptBlock { $PSVersionTable.PSVersion.Major } -ErrorAction Stop
                 $version | Should -BeGreaterOrEqual 7
@@ -1259,7 +1260,7 @@ Describe 'End-to-End Client Transport Tests' {
         }
 
         It 'Passes arguments over WinRM' {
-            $session = New-PSHostSession -ComputerName 'localhost' -Port $script:WinRMPort -Credential $script:WinRMCredential
+            $session = New-PSHostSession -ComputerName 'localhost' -Port $script:WinRMPort -Credential $script:WinRMCredential -OpenTimeout $script:WinRMOpenTimeout
             try {
                 $result = Invoke-Command -Session $session -ScriptBlock { param($x) $x * 3 } -ArgumentList 5 -ErrorAction Stop
                 $result | Should -Be 15
@@ -1270,7 +1271,7 @@ Describe 'End-to-End Client Transport Tests' {
         }
 
         It 'Connects to WinRM server using ConnectionUri' {
-            $session = New-PSHostSession -ConnectionUri "http://localhost:$($script:WinRMPort)/wsman" -Credential $script:WinRMCredential
+            $session = New-PSHostSession -ConnectionUri "http://localhost:$($script:WinRMPort)/wsman" -Credential $script:WinRMCredential -OpenTimeout $script:WinRMOpenTimeout
             try {
                 $session | Should -Not -BeNullOrEmpty
                 $session.State | Should -Be 'Opened'

--- a/tests/AwakeCoding.PSRemoting.Tests.ps1
+++ b/tests/AwakeCoding.PSRemoting.Tests.ps1
@@ -49,6 +49,36 @@ BeforeAll {
             }
         }
     }
+
+    function script:New-TestPSCredential {
+        param(
+            [Parameter(Mandatory)]
+            [string]$UserName,
+
+            [Parameter(Mandatory)]
+            [string]$Password
+        )
+
+        return [PSCredential]::new(
+            $UserName,
+            (ConvertTo-SecureString $Password -AsPlainText -Force))
+    }
+
+    function script:Invoke-TestWinRMConnectionInfo {
+        param(
+            [Parameter(Mandatory)]
+            [scriptblock]$Configure
+        )
+
+        $command = [AwakeCoding.PSRemoting.PowerShell.NewPSHostSessionCommand]::new()
+        & $Configure $command
+
+        $method = $command.GetType().BaseType.GetMethod(
+            'CreateWinRMConnectionInfo',
+            [System.Reflection.BindingFlags]'Instance, NonPublic')
+
+        return $method.Invoke($command, @())
+    }
 }
 
 AfterAll {
@@ -96,6 +126,20 @@ Describe 'Module Manifest Tests' {
 }
 
 Describe 'New-PSHostSession Cmdlet Tests' {
+    Context 'Parameter Surface' {
+        It 'Exposes WinRM via ComputerName and ConnectionUri instead of WinRMTransport' {
+            $command = Get-Command New-PSHostSession
+
+            $command.Parameters.ContainsKey('ComputerName') | Should -BeTrue
+            $command.Parameters.ContainsKey('ConnectionUri') | Should -BeTrue
+            $command.Parameters.ContainsKey('UserName') | Should -BeTrue
+            $command.Parameters.ContainsKey('Password') | Should -BeTrue
+            $command.Parameters.ContainsKey('UseImplicitCredential') | Should -BeTrue
+            $command.Parameters.ContainsKey('AuthenticationProvider') | Should -BeFalse
+            $command.Parameters.ContainsKey('WinRMTransport') | Should -BeFalse
+        }
+    }
+
     Context 'Basic Functionality' {
         It 'Creates a PSSession successfully' {
             $session = New-PSHostSession
@@ -845,10 +889,60 @@ Describe 'Unified Server Cmdlet Tests' {
         }
     }
 
-    Context 'Mixed Transport Tests' {
+    Context 'WinRM Server Tests' {
         AfterEach {
-            Get-PSHostServer -ErrorAction SilentlyContinue | Stop-PSHostServer -Force -ErrorAction SilentlyContinue
+            Get-PSHostServer -TransportType WinRM -ErrorAction SilentlyContinue | Stop-PSHostServer -Force -ErrorAction SilentlyContinue
         }
+
+        It 'Can start and stop a WinRM server' {
+            $server = Start-PSHostServer -TransportType WinRM -Port 19855
+            try {
+                $server | Should -Not -BeNullOrEmpty
+                $server.State | Should -Be 'Running'
+                $server.Port | Should -Be 19855
+            }
+            finally {
+                Stop-PSHostServer -Server $server -Force
+            }
+            $server.State | Should -Be 'Stopped'
+        }
+
+        It 'WinRM server has expected properties' {
+            $server = Start-PSHostServer -TransportType WinRM -Port 19856
+            try {
+                $server.Port | Should -Be 19856
+                $server.ListenerPrefix | Should -Match 'http://127.0.0.1:19856/'
+                $server | Should -BeOfType 'AwakeCoding.PSRemoting.PowerShell.PSHostWinRMServer'
+            }
+            finally {
+                Stop-PSHostServer -Server $server -Force
+            }
+        }
+
+        It 'Throws error if WinRM port is duplicate' {
+            $server = Start-PSHostServer -TransportType WinRM -Port 19857
+            try {
+                { Start-PSHostServer -TransportType WinRM -Port 19857 -ErrorAction Stop } | Should -Throw
+            }
+            finally {
+                Stop-PSHostServer -Server $server -Force
+            }
+        }
+
+        It 'Can retrieve WinRM server with TransportType filter' {
+            $server = Start-PSHostServer -TransportType WinRM -Port 19858
+            try {
+                $found = Get-PSHostServer -TransportType WinRM
+                $found | Should -HaveCount 1
+                $found.Port | Should -Be 19858
+            }
+            finally {
+                Stop-PSHostServer -Server $server -Force
+            }
+        }
+    }
+
+    Context 'Mixed Transport Tests' {
 
         It 'Can run all three transport types simultaneously' {
             $tcpServer = Start-PSHostServer -TransportType TCP -Port 0
@@ -1046,6 +1140,164 @@ Describe 'End-to-End Client Transport Tests' {
 
         It 'Throws timeout error when named pipe does not exist' {
             { New-PSHostSession -PipeName 'NonExistentPipe12345' -OpenTimeout 2000 -ErrorAction Stop } | Should -Throw
+        }
+    }
+
+    Context 'WinRM Client Info' {
+        It 'Clones the WinRM implicit credential flag' {
+            $info = [AwakeCoding.PSRemoting.PowerShell.WinRMClientInfo]::new('server01')
+            $info.UseImplicitCredential = $true
+
+            $clone = $info.Clone()
+
+            $clone.UseImplicitCredential | Should -BeTrue
+        }
+
+        It 'Builds WinRM credentials from UserName and Password' {
+            $info = Invoke-TestWinRMConnectionInfo {
+                param($command)
+
+                $command.ComputerName = 'server02'
+                $command.UserName = 'CONTOSO\User01'
+                $command.Password = ConvertTo-SecureString 'Secret123!' -AsPlainText -Force
+            }
+
+            $info.Credential | Should -Not -BeNullOrEmpty
+            $info.Credential.UserName | Should -Be 'CONTOSO\User01'
+            $info.Credential.GetNetworkCredential().Password | Should -Be 'Secret123!'
+            $info.UseImplicitCredential | Should -BeFalse
+        }
+
+        It 'Rejects Password without UserName for WinRM' {
+            {
+                Invoke-TestWinRMConnectionInfo {
+                    param($command)
+
+                    $command.ComputerName = 'server03'
+                    $command.Password = ConvertTo-SecureString 'Secret123!' -AsPlainText -Force
+                }
+            } | Should -Throw -ExpectedMessage '*Specify -UserName when using -Password*'
+        }
+
+        It 'Rejects Credential combined with UserName for WinRM' {
+            {
+                Invoke-TestWinRMConnectionInfo {
+                    param($command)
+
+                    $command.ComputerName = 'server04'
+                    $command.Credential = New-TestPSCredential -UserName 'user' -Password 'pass'
+                    $command.UserName = 'other-user'
+                }
+            } | Should -Throw -ExpectedMessage '*Do not combine -Credential with -UserName or -Password*'
+        }
+
+        It 'Requires prompt-capable host when WinRM credentials are omitted' {
+            {
+                Invoke-TestWinRMConnectionInfo {
+                    param($command)
+
+                    $command.ComputerName = 'server05'
+                }
+            } | Should -Throw -ExpectedMessage '*WinRM connections require explicit credentials by default*'
+        }
+
+        It 'Rejects WinRM implicit credentials with Basic authentication' {
+            {
+                Invoke-TestWinRMConnectionInfo {
+                    param($command)
+
+                    $command.ComputerName = 'server06'
+                    $command.Authentication = [AwakeCoding.PSRemoting.PowerShell.WinRMAuthenticationMechanism]::Basic
+                    $command.UseImplicitCredential = $true
+                }
+            } | Should -Throw -ExpectedMessage '*implicit credentials cannot be used with Basic authentication*'
+        }
+    }
+
+    Context 'WinRM Client Transport' {
+        BeforeAll {
+            $script:WinRMPort = Get-Random -Minimum 22000 -Maximum 24000
+            $script:WinRMServer = Start-PSHostServer -TransportType WinRM -Port $script:WinRMPort -Name 'WinRME2ETest'
+            $script:WinRMCredential = New-TestPSCredential -UserName 'winrm-user' -Password 'winrm-pass'
+        }
+
+        AfterAll {
+            Stop-PSHostServer -Server $script:WinRMServer -Force -ErrorAction SilentlyContinue
+        }
+
+        It 'Connects to WinRM server and creates session' {
+            $session = New-PSHostSession -ComputerName 'localhost' -Port $script:WinRMPort -Credential $script:WinRMCredential
+            try {
+                $session | Should -Not -BeNullOrEmpty
+                $session.State | Should -Be 'Opened'
+            }
+            finally {
+                Remove-PSHostSessionSafely -Session $session
+            }
+        }
+
+        It 'Executes arithmetic over WinRM transport' {
+            $session = New-PSHostSession -ComputerName 'localhost' -Port $script:WinRMPort -Credential $script:WinRMCredential
+            try {
+                $result = Invoke-Command -Session $session -ScriptBlock { 6 + 7 } -ErrorAction Stop
+                $result | Should -Be 13
+            }
+            finally {
+                Remove-PSHostSessionSafely -Session $session
+            }
+        }
+
+        It 'Retrieves PSVersionTable over WinRM' {
+            $session = New-PSHostSession -ComputerName 'localhost' -Port $script:WinRMPort -Credential $script:WinRMCredential
+            try {
+                $version = Invoke-Command -Session $session -ScriptBlock { $PSVersionTable.PSVersion.Major } -ErrorAction Stop
+                $version | Should -BeGreaterOrEqual 7
+            }
+            finally {
+                Remove-PSHostSessionSafely -Session $session
+            }
+        }
+
+        It 'Passes arguments over WinRM' {
+            $session = New-PSHostSession -ComputerName 'localhost' -Port $script:WinRMPort -Credential $script:WinRMCredential
+            try {
+                $result = Invoke-Command -Session $session -ScriptBlock { param($x) $x * 3 } -ArgumentList 5 -ErrorAction Stop
+                $result | Should -Be 15
+            }
+            finally {
+                Remove-PSHostSessionSafely -Session $session
+            }
+        }
+
+        It 'Connects to WinRM server using ConnectionUri' {
+            $session = New-PSHostSession -ConnectionUri "http://localhost:$($script:WinRMPort)/wsman" -Credential $script:WinRMCredential
+            try {
+                $session | Should -Not -BeNullOrEmpty
+                $session.State | Should -Be 'Opened'
+            }
+            finally {
+                Remove-PSHostSessionSafely -Session $session
+            }
+        }
+
+        It 'Rejects connection with wrong credentials when auth is enabled' {
+            $requiredCred = New-TestPSCredential -UserName 'user' -Password 'goodpass'
+            $wrongCred = New-TestPSCredential -UserName 'user' -Password 'badpass'
+            $serverWithAuth = Start-PSHostServer -TransportType WinRM -Port ($script:WinRMPort + 1) -Credential $requiredCred
+            try {
+                {
+                    New-PSHostSession `
+                        -ComputerName 'localhost' `
+                        -Port ($script:WinRMPort + 1) `
+                        -Authentication Basic `
+                        -Credential $wrongCred `
+                        -OpenTimeout 5000 `
+                        -ErrorAction Stop
+                } | Should -Throw
+            }
+            finally {
+                Stop-PSHostServer -Server $serverWithAuth -Force -ErrorAction SilentlyContinue
+            }
         }
     }
 }

--- a/tests/AwakeCoding.PSRemoting.Tests.ps1
+++ b/tests/AwakeCoding.PSRemoting.Tests.ps1
@@ -113,7 +113,18 @@ BeforeAll {
             [int]$TimeoutSeconds = 30
         )
 
-        $job = Invoke-Command -Session $Session -ScriptBlock $ScriptBlock -ArgumentList $ArgumentList -AsJob
+        $job = $null
+
+        if (Get-Command Start-ThreadJob -ErrorAction SilentlyContinue) {
+            $job = Start-ThreadJob -ScriptBlock {
+                param($RemoteSession, $RemoteScriptBlock, $RemoteArgumentList)
+
+                Invoke-Command -Session $RemoteSession -ScriptBlock $RemoteScriptBlock -ArgumentList $RemoteArgumentList -ErrorAction Stop
+            } -ArgumentList $Session, $ScriptBlock, $ArgumentList
+        }
+        else {
+            $job = Invoke-Command -Session $Session -ScriptBlock $ScriptBlock -ArgumentList $ArgumentList -AsJob
+        }
 
         try {
             $completed = Wait-Job -Job $job -Timeout $TimeoutSeconds

--- a/tests/AwakeCoding.PSRemoting.Tests.ps1
+++ b/tests/AwakeCoding.PSRemoting.Tests.ps1
@@ -64,6 +64,42 @@ BeforeAll {
             (ConvertTo-SecureString $Password -AsPlainText -Force))
     }
 
+    function script:New-TestWinRMSession {
+        param(
+            [string]$ComputerName = 'localhost',
+
+            [int]$Port,
+
+            [string]$ConnectionUri,
+
+            [Parameter(Mandatory)]
+            [PSCredential]$Credential,
+
+            [int]$OpenTimeout = 60000,
+
+            [int]$MaxAttempts = 2,
+
+            [int]$RetryDelayMilliseconds = 1000
+        )
+
+        for ($attempt = 1; $attempt -le $MaxAttempts; $attempt++) {
+            try {
+                if ($PSBoundParameters.ContainsKey('ConnectionUri')) {
+                    return New-PSHostSession -ConnectionUri $ConnectionUri -Credential $Credential -OpenTimeout $OpenTimeout -ErrorAction Stop
+                }
+
+                return New-PSHostSession -ComputerName $ComputerName -Port $Port -Credential $Credential -OpenTimeout $OpenTimeout -ErrorAction Stop
+            }
+            catch [System.TimeoutException] {
+                if ($attempt -ge $MaxAttempts) {
+                    throw
+                }
+
+                Start-Sleep -Milliseconds $RetryDelayMilliseconds
+            }
+        }
+    }
+
     function script:Invoke-TestWinRMConnectionInfo {
         param(
             [Parameter(Mandatory)]
@@ -1227,7 +1263,7 @@ Describe 'End-to-End Client Transport Tests' {
         }
 
         It 'Connects to WinRM server and creates session' {
-            $session = New-PSHostSession -ComputerName 'localhost' -Port $script:WinRMPort -Credential $script:WinRMCredential -OpenTimeout $script:WinRMOpenTimeout
+            $session = New-TestWinRMSession -Port $script:WinRMPort -Credential $script:WinRMCredential -OpenTimeout $script:WinRMOpenTimeout
             try {
                 $session | Should -Not -BeNullOrEmpty
                 $session.State | Should -Be 'Opened'
@@ -1238,7 +1274,7 @@ Describe 'End-to-End Client Transport Tests' {
         }
 
         It 'Executes arithmetic over WinRM transport' {
-            $session = New-PSHostSession -ComputerName 'localhost' -Port $script:WinRMPort -Credential $script:WinRMCredential -OpenTimeout $script:WinRMOpenTimeout
+            $session = New-TestWinRMSession -Port $script:WinRMPort -Credential $script:WinRMCredential -OpenTimeout $script:WinRMOpenTimeout
             try {
                 $result = Invoke-Command -Session $session -ScriptBlock { 6 + 7 } -ErrorAction Stop
                 $result | Should -Be 13
@@ -1249,7 +1285,7 @@ Describe 'End-to-End Client Transport Tests' {
         }
 
         It 'Retrieves PSVersionTable over WinRM' {
-            $session = New-PSHostSession -ComputerName 'localhost' -Port $script:WinRMPort -Credential $script:WinRMCredential -OpenTimeout $script:WinRMOpenTimeout
+            $session = New-TestWinRMSession -Port $script:WinRMPort -Credential $script:WinRMCredential -OpenTimeout $script:WinRMOpenTimeout
             try {
                 $version = Invoke-Command -Session $session -ScriptBlock { $PSVersionTable.PSVersion.Major } -ErrorAction Stop
                 $version | Should -BeGreaterOrEqual 7
@@ -1260,7 +1296,7 @@ Describe 'End-to-End Client Transport Tests' {
         }
 
         It 'Passes arguments over WinRM' {
-            $session = New-PSHostSession -ComputerName 'localhost' -Port $script:WinRMPort -Credential $script:WinRMCredential -OpenTimeout $script:WinRMOpenTimeout
+            $session = New-TestWinRMSession -Port $script:WinRMPort -Credential $script:WinRMCredential -OpenTimeout $script:WinRMOpenTimeout
             try {
                 $result = Invoke-Command -Session $session -ScriptBlock { param($x) $x * 3 } -ArgumentList 5 -ErrorAction Stop
                 $result | Should -Be 15
@@ -1271,7 +1307,7 @@ Describe 'End-to-End Client Transport Tests' {
         }
 
         It 'Connects to WinRM server using ConnectionUri' {
-            $session = New-PSHostSession -ConnectionUri "http://localhost:$($script:WinRMPort)/wsman" -Credential $script:WinRMCredential -OpenTimeout $script:WinRMOpenTimeout
+            $session = New-TestWinRMSession -ConnectionUri "http://localhost:$($script:WinRMPort)/wsman" -Credential $script:WinRMCredential -OpenTimeout $script:WinRMOpenTimeout
             try {
                 $session | Should -Not -BeNullOrEmpty
                 $session.State | Should -Be 'Opened'

--- a/tests/AwakeCoding.PSRemoting.Tests.ps1
+++ b/tests/AwakeCoding.PSRemoting.Tests.ps1
@@ -100,6 +100,35 @@ BeforeAll {
         }
     }
 
+    function script:Invoke-TestCommandWithTimeout {
+        param(
+            [Parameter(Mandatory)]
+            [System.Management.Automation.Runspaces.PSSession]$Session,
+
+            [Parameter(Mandatory)]
+            [scriptblock]$ScriptBlock,
+
+            [object[]]$ArgumentList,
+
+            [int]$TimeoutSeconds = 30
+        )
+
+        $job = Invoke-Command -Session $Session -ScriptBlock $ScriptBlock -ArgumentList $ArgumentList -AsJob
+
+        try {
+            $completed = Wait-Job -Job $job -Timeout $TimeoutSeconds
+            if ($null -eq $completed) {
+                Stop-Job -Job $job -ErrorAction SilentlyContinue
+                throw "Invoke-Command timed out after ${TimeoutSeconds}s"
+            }
+
+            return Receive-Job -Job $job -Wait -AutoRemoveJob -ErrorAction Stop
+        }
+        finally {
+            Remove-Job -Job $job -Force -ErrorAction SilentlyContinue
+        }
+    }
+
     function script:Invoke-TestWinRMConnectionInfo {
         param(
             [Parameter(Mandatory)]
@@ -1256,6 +1285,7 @@ Describe 'End-to-End Client Transport Tests' {
             $script:WinRMServer = Start-PSHostServer -TransportType WinRM -Port $script:WinRMPort -Name 'WinRME2ETest'
             $script:WinRMCredential = New-TestPSCredential -UserName 'winrm-user' -Password 'winrm-pass'
             $script:WinRMOpenTimeout = 60000
+            $script:WinRMCommandTimeoutSeconds = 30
         }
 
         AfterAll {
@@ -1276,7 +1306,7 @@ Describe 'End-to-End Client Transport Tests' {
         It 'Executes arithmetic over WinRM transport' {
             $session = New-TestWinRMSession -Port $script:WinRMPort -Credential $script:WinRMCredential -OpenTimeout $script:WinRMOpenTimeout
             try {
-                $result = Invoke-Command -Session $session -ScriptBlock { 6 + 7 } -ErrorAction Stop
+                $result = Invoke-TestCommandWithTimeout -Session $session -ScriptBlock { 6 + 7 } -TimeoutSeconds $script:WinRMCommandTimeoutSeconds
                 $result | Should -Be 13
             }
             finally {
@@ -1287,7 +1317,7 @@ Describe 'End-to-End Client Transport Tests' {
         It 'Retrieves PSVersionTable over WinRM' {
             $session = New-TestWinRMSession -Port $script:WinRMPort -Credential $script:WinRMCredential -OpenTimeout $script:WinRMOpenTimeout
             try {
-                $version = Invoke-Command -Session $session -ScriptBlock { $PSVersionTable.PSVersion.Major } -ErrorAction Stop
+                $version = Invoke-TestCommandWithTimeout -Session $session -ScriptBlock { $PSVersionTable.PSVersion.Major } -TimeoutSeconds $script:WinRMCommandTimeoutSeconds
                 $version | Should -BeGreaterOrEqual 7
             }
             finally {
@@ -1298,7 +1328,7 @@ Describe 'End-to-End Client Transport Tests' {
         It 'Passes arguments over WinRM' {
             $session = New-TestWinRMSession -Port $script:WinRMPort -Credential $script:WinRMCredential -OpenTimeout $script:WinRMOpenTimeout
             try {
-                $result = Invoke-Command -Session $session -ScriptBlock { param($x) $x * 3 } -ArgumentList 5 -ErrorAction Stop
+                $result = Invoke-TestCommandWithTimeout -Session $session -ScriptBlock { param($x) $x * 3 } -ArgumentList 5 -TimeoutSeconds $script:WinRMCommandTimeoutSeconds
                 $result | Should -Be 15
             }
             finally {


### PR DESCRIPTION
## Summary
- add a module-owned WinRM client and server over WSMan/SOAP without depending on the system WinRM stack
- bundle `Devolutions.Sspi` runtime assets for Negotiate/Kerberos with automatic Windows SSPI fallback
- align WinRM session parameters with `-ComputerName` and `-ConnectionUri`
- default WinRM to explicit credentials with prompting, plus `-UserName`/`-Password` and `-UseImplicitCredential`
- keep SSPI backend selection internal and cover the module-hosted WinRM path with end-to-end tests

## Testing
- `./build.ps1`
- full Pester suite: `93 passed, 0 failed, 9 skipped`