### PR TITLE
Add gRPC PSRemoting transport

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -21,12 +21,15 @@ Copy-Item "$PSScriptRoot\src\AwakeCoding.PSRemoting.psd1" $ModulePath -Force
 # Copy the main module DLL
 Copy-Item "$OutputPath\AwakeCoding.PSRemoting.PowerShell.dll" $ModulePath -Force
 
-# Copy required dependency DLLs (Tmds.Ssh and its dependencies)
+# Copy required dependency DLLs (Tmds.Ssh, gRPC, and their managed dependencies)
 $Dependencies = @(
     "Tmds.Ssh.dll",
     "BouncyCastle.Cryptography.dll",
     "Microsoft.Extensions.Logging.Abstractions.dll",
-    "Microsoft.Extensions.DependencyInjection.Abstractions.dll"
+    "Microsoft.Extensions.DependencyInjection.Abstractions.dll",
+    "Google.Protobuf.dll",
+    "Grpc.Core.Api.dll",
+    "Grpc.Core.dll"
 )
 
 foreach ($dll in $Dependencies) {

--- a/src/AwakeCoding.PSRemoting.PowerShell.csproj
+++ b/src/AwakeCoding.PSRemoting.PowerShell.csproj
@@ -16,12 +16,19 @@
 
   <ItemGroup>
     <PackageReference Include="Devolutions.Sspi" Version="2026.3.27" ExcludeAssets="build;buildTransitive" />
+    <PackageReference Include="Google.Protobuf" Version="3.32.1" />
+    <PackageReference Include="Grpc.Core" Version="2.46.6" />
+    <PackageReference Include="Grpc.Tools" Version="2.72.0" PrivateAssets="all" />
     <PackageReference Include="System.Management.Automation" Version="7.4.*" PrivateAssets="all" />
     <PackageReference Include="System.Net.Http.WinHttpHandler" Version="*" />
     <PackageReference Include="Tmds.Ssh" Version="0.11.0" />
     <Reference Include="System.Management.Automation">
       <HintPath>.\Ref\System.Management.Automation.dll</HintPath>
     </Reference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Protobuf Include="Protos\pshostgrpc.proto" GrpcServices="Both" />
   </ItemGroup>
 
 </Project>

--- a/src/AwakeCoding.PSRemoting.psd1
+++ b/src/AwakeCoding.PSRemoting.psd1
@@ -55,7 +55,10 @@ RequiredAssemblies = @(
     'Tmds.Ssh.dll',
     'BouncyCastle.Cryptography.dll',
     'Microsoft.Extensions.Logging.Abstractions.dll',
-    'Microsoft.Extensions.DependencyInjection.Abstractions.dll'
+    'Microsoft.Extensions.DependencyInjection.Abstractions.dll',
+    'Google.Protobuf.dll',
+    'Grpc.Core.Api.dll',
+    'Grpc.Core.dll'
 )
 
 # Script files (.ps1) that are run in the caller's environment prior to importing this module.

--- a/src/PSHostGrpcClientTransport.cs
+++ b/src/PSHostGrpcClientTransport.cs
@@ -1,0 +1,365 @@
+using System;
+using System.IO;
+using System.Management.Automation;
+using System.Management.Automation.Internal;
+using System.Management.Automation.Remoting;
+using System.Management.Automation.Remoting.Client;
+using System.Management.Automation.Runspaces;
+using System.Text;
+using System.Threading;
+using Google.Protobuf;
+using Grpc.Core;
+using AwakeCoding.PSRemoting.PowerShell.Grpc;
+
+namespace AwakeCoding.PSRemoting.PowerShell
+{
+    /// <summary>
+    /// Connection info for gRPC-based PowerShell remoting client connections.
+    /// </summary>
+    internal sealed class PSHostGrpcClientInfo : RunspaceConnectionInfo
+    {
+        public override string ComputerName { get; set; }
+
+        public Uri GrpcUri { get; set; }
+
+        public new int OpenTimeout { get; set; } = 30000;
+
+        public override PSCredential? Credential
+        {
+            get { return null; }
+            set { throw new NotImplementedException(); }
+        }
+
+        public override AuthenticationMechanism AuthenticationMechanism
+        {
+            get { return AuthenticationMechanism.Default; }
+            set { throw new NotImplementedException(); }
+        }
+
+        public override string CertificateThumbprint
+        {
+            get { return string.Empty; }
+            set { throw new NotImplementedException(); }
+        }
+
+        public PSHostGrpcClientInfo(Uri grpcUri)
+        {
+            GrpcUri = grpcUri;
+            ComputerName = grpcUri.Host;
+        }
+
+        public override RunspaceConnectionInfo Clone()
+        {
+            return new PSHostGrpcClientInfo(GrpcUri)
+            {
+                OpenTimeout = OpenTimeout
+            };
+        }
+
+        public override BaseClientSessionTransportManager CreateClientSessionTransportManager(
+            Guid instanceId,
+            string sessionName,
+            PSRemotingCryptoHelper cryptoHelper)
+        {
+            return new PSHostGrpcClientSessionTransportMgr(
+                connectionInfo: this,
+                runspaceId: instanceId,
+                cryptoHelper: cryptoHelper);
+        }
+    }
+
+    /// <summary>
+    /// Transport manager for gRPC client connections to PSHostServer.
+    /// </summary>
+    internal sealed class PSHostGrpcClientSessionTransportMgr : ClientSessionTransportManagerBase
+    {
+        private const string ThreadName = "PSHostGrpcClient Reader Thread";
+
+        private readonly PSHostGrpcClientInfo _connectionInfo;
+        private readonly object _sendLock = new object();
+
+        private Channel? _channel;
+        private AsyncDuplexStreamingCall<PSHostGrpcFrame, PSHostGrpcFrame>? _call;
+        private CancellationTokenSource? _readerCts;
+        private volatile bool _isClosed;
+
+        internal PSHostGrpcClientSessionTransportMgr(
+            PSHostGrpcClientInfo connectionInfo,
+            Guid runspaceId,
+            PSRemotingCryptoHelper cryptoHelper)
+            : base(runspaceId, cryptoHelper)
+        {
+            if (connectionInfo == null) { throw new PSArgumentException("connectionInfo"); }
+            _connectionInfo = connectionInfo;
+        }
+
+        public override void CreateAsync()
+        {
+            ChannelCredentials credentials = _connectionInfo.GrpcUri.Scheme.Equals("grpcs", StringComparison.OrdinalIgnoreCase)
+                ? new SslCredentials()
+                : ChannelCredentials.Insecure;
+
+            _channel = new Channel(_connectionInfo.GrpcUri.Host, _connectionInfo.GrpcUri.Port, credentials);
+
+            try
+            {
+                _channel.ConnectAsync(DateTime.UtcNow.AddMilliseconds(_connectionInfo.OpenTimeout)).GetAwaiter().GetResult();
+            }
+            catch (RpcException ex) when (ex.StatusCode == StatusCode.DeadlineExceeded)
+            {
+                throw new TimeoutException($"gRPC connection to {_connectionInfo.GrpcUri} timed out after {_connectionInfo.OpenTimeout}ms", ex);
+            }
+            catch (TimeoutException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                throw new IOException($"Failed to connect to gRPC endpoint '{_connectionInfo.GrpcUri}'", ex);
+            }
+
+            var client = new PSHostGrpcTransport.PSHostGrpcTransportClient(_channel);
+            _call = client.Connect();
+
+            SetMessageWriter(new GrpcTextWriter(this));
+
+            _readerCts = new CancellationTokenSource();
+            StartReaderThread();
+
+            SendOneItem();
+        }
+
+        internal void SendData(string data)
+        {
+            if (_isClosed)
+            {
+                throw new IOException("The gRPC transport is closed.");
+            }
+
+            var call = _call ?? throw new InvalidOperationException("The gRPC stream has not been opened.");
+
+            lock (_sendLock)
+            {
+                try
+                {
+                    call.RequestStream.WriteAsync(new PSHostGrpcFrame
+                    {
+                        Kind = PSHostGrpcFrameKind.Input,
+                        Payload = ByteString.CopyFrom(data, Encoding.UTF8)
+                    }).GetAwaiter().GetResult();
+                }
+                catch (Exception ex)
+                {
+                    throw new IOException($"Failed to send data to gRPC endpoint '{_connectionInfo.GrpcUri}'", ex);
+                }
+            }
+        }
+
+        public override void CloseAsync()
+        {
+            base.CloseAsync();
+        }
+
+        private void StartReaderThread()
+        {
+            Thread readerThread = new Thread(ProcessReaderThread)
+            {
+                Name = ThreadName,
+                IsBackground = true
+            };
+            readerThread.Start();
+        }
+
+        private void ProcessReaderThread()
+        {
+            var outputBuffer = new StringBuilder();
+            var errorBuffer = new StringBuilder();
+
+            try
+            {
+                while (_readerCts != null && !_readerCts.IsCancellationRequested && _call != null)
+                {
+                    bool hasFrame;
+                    try
+                    {
+                        hasFrame = _call.ResponseStream.MoveNext(_readerCts.Token).GetAwaiter().GetResult();
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        break;
+                    }
+                    catch (RpcException ex) when (ex.StatusCode == StatusCode.Cancelled)
+                    {
+                        break;
+                    }
+                    catch (RpcException ex) when (ex.StatusCode == StatusCode.Unavailable && _isClosed)
+                    {
+                        break;
+                    }
+
+                    if (!hasFrame)
+                    {
+                        break;
+                    }
+
+                    var frame = _call.ResponseStream.Current;
+                    switch (frame.Kind)
+                    {
+                        case PSHostGrpcFrameKind.Output:
+                            ProcessPayload(frame.Payload, outputBuffer, HandleOutputDataReceived);
+                            break;
+
+                        case PSHostGrpcFrameKind.Error:
+                            ProcessPayload(frame.Payload, errorBuffer, HandleErrorDataReceived);
+                            break;
+
+                        case PSHostGrpcFrameKind.Close:
+                            return;
+                    }
+                }
+            }
+            catch (ObjectDisposedException)
+            {
+                // Normal reader thread end during cleanup.
+            }
+        }
+
+        private static void ProcessPayload(ByteString payload, StringBuilder lineBuffer, Action<string?> handler)
+        {
+            if (payload.Length == 0)
+            {
+                return;
+            }
+
+            lineBuffer.Append(payload.ToStringUtf8());
+            string bufferContent = lineBuffer.ToString();
+            int lastNewlineIndex = bufferContent.LastIndexOf('\n');
+
+            if (lastNewlineIndex < 0)
+            {
+                return;
+            }
+
+            string completeData = bufferContent.Substring(0, lastNewlineIndex + 1);
+            lineBuffer.Clear();
+
+            if (lastNewlineIndex < bufferContent.Length - 1)
+            {
+                lineBuffer.Append(bufferContent.Substring(lastNewlineIndex + 1));
+            }
+
+            using var reader = new StringReader(completeData);
+            string? line;
+            while ((line = reader.ReadLine()) != null)
+            {
+                if (!string.IsNullOrEmpty(line))
+                {
+                    handler(line);
+                }
+            }
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            if (isDisposing)
+            {
+                CleanupConnection();
+            }
+
+            base.Dispose(isDisposing);
+        }
+
+        protected override void CleanupConnection()
+        {
+            _isClosed = true;
+
+            try
+            {
+                _readerCts?.Cancel();
+            }
+            catch { }
+
+            try
+            {
+                _call?.RequestStream.CompleteAsync().Wait(1000);
+            }
+            catch { }
+
+            try
+            {
+                _call?.Dispose();
+            }
+            catch { }
+
+            try
+            {
+                _channel?.ShutdownAsync().Wait(1000);
+            }
+            catch { }
+
+            _readerCts?.Dispose();
+            _readerCts = null;
+            _call = null;
+            _channel = null;
+        }
+    }
+
+    /// <summary>
+    /// Custom TextWriter that sends line-oriented remoting records over gRPC.
+    /// </summary>
+    internal sealed class GrpcTextWriter : TextWriter
+    {
+        private readonly PSHostGrpcClientSessionTransportMgr _transportMgr;
+        private readonly StringBuilder _lineBuffer = new StringBuilder();
+
+        public override Encoding Encoding => Encoding.UTF8;
+
+        public GrpcTextWriter(PSHostGrpcClientSessionTransportMgr transportMgr)
+        {
+            _transportMgr = transportMgr;
+        }
+
+        public override void Write(char value)
+        {
+            _lineBuffer.Append(value);
+
+            if (value == '\n')
+            {
+                Flush();
+            }
+        }
+
+        public override void Write(string? value)
+        {
+            if (value == null)
+            {
+                return;
+            }
+
+            _lineBuffer.Append(value);
+
+            if (value.EndsWith('\n'))
+            {
+                Flush();
+            }
+        }
+
+        public override void WriteLine(string? value)
+        {
+            _lineBuffer.Append(value);
+            _lineBuffer.Append('\n');
+            Flush();
+        }
+
+        public override void Flush()
+        {
+            if (_lineBuffer.Length == 0)
+            {
+                return;
+            }
+
+            _transportMgr.SendData(_lineBuffer.ToString());
+            _lineBuffer.Clear();
+        }
+    }
+}

--- a/src/PSHostGrpcClientTransport.cs
+++ b/src/PSHostGrpcClientTransport.cs
@@ -95,6 +95,8 @@ namespace AwakeCoding.PSRemoting.PowerShell
 
         public override void CreateAsync()
         {
+            PSHostGrpcPlatform.EnsureSupported();
+
             ChannelCredentials credentials = _connectionInfo.GrpcUri.Scheme.Equals("grpcs", StringComparison.OrdinalIgnoreCase)
                 ? new SslCredentials()
                 : ChannelCredentials.Insecure;

--- a/src/PSHostGrpcPlatform.cs
+++ b/src/PSHostGrpcPlatform.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace AwakeCoding.PSRemoting.PowerShell
+{
+    internal static class PSHostGrpcPlatform
+    {
+        public static bool IsSupported =>
+            !(RuntimeInformation.IsOSPlatform(OSPlatform.OSX) &&
+              RuntimeInformation.ProcessArchitecture == Architecture.Arm64);
+
+        public static void EnsureSupported()
+        {
+            if (!IsSupported)
+            {
+                throw new PlatformNotSupportedException("The Grpc.Core native runtime used by this transport does not support macOS arm64.");
+            }
+        }
+    }
+}

--- a/src/PSHostGrpcServer.cs
+++ b/src/PSHostGrpcServer.cs
@@ -50,6 +50,8 @@ namespace AwakeCoding.PSRemoting.PowerShell
 
         public override void StartListenerAsync()
         {
+            PSHostGrpcPlatform.EnsureSupported();
+
             if (State == ServerState.Running || State == ServerState.Starting)
             {
                 throw new InvalidOperationException($"Server '{Name}' is already {State}");

--- a/src/PSHostGrpcServer.cs
+++ b/src/PSHostGrpcServer.cs
@@ -1,0 +1,416 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+using Google.Protobuf;
+using Grpc.Core;
+using AwakeCoding.PSRemoting.PowerShell.Grpc;
+
+namespace AwakeCoding.PSRemoting.PowerShell
+{
+    /// <summary>
+    /// gRPC-based PowerShell remoting server.
+    /// </summary>
+    public sealed class PSHostGrpcServer : PSHostServerBase
+    {
+        private const int BufferSize = 8192;
+
+        private Server? _grpcServer;
+
+        public bool UseSecureConnection { get; private set; }
+
+        public bool AllowUnencrypted { get; private set; }
+
+        public string GrpcUri
+        {
+            get
+            {
+                string scheme = UseSecureConnection ? "grpcs" : "grpc";
+                return $"{scheme}://{ListenAddress}:{Port}";
+            }
+        }
+
+        public PSHostGrpcServer(
+            string name,
+            int port,
+            string listenAddress,
+            bool useSecureConnection,
+            bool allowUnencrypted,
+            int maxConnections,
+            int drainTimeout)
+            : base(name, port, listenAddress, maxConnections, drainTimeout)
+        {
+            UseSecureConnection = useSecureConnection;
+            AllowUnencrypted = allowUnencrypted;
+        }
+
+        public override void StartListenerAsync()
+        {
+            if (State == ServerState.Running || State == ServerState.Starting)
+            {
+                throw new InvalidOperationException($"Server '{Name}' is already {State}");
+            }
+
+            if (UseSecureConnection)
+            {
+                throw new NotSupportedException("gRPC TLS server credentials are not implemented yet. Use loopback plaintext gRPC for this module transport.");
+            }
+
+            if (!AllowUnencrypted && !IsLoopbackAddress(ListenAddress))
+            {
+                throw new InvalidOperationException("Plaintext gRPC is allowed only on loopback by default. Specify -AllowUnencrypted to bind plaintext gRPC to a non-loopback address.");
+            }
+
+            State = ServerState.Starting;
+
+            try
+            {
+                _serverInstance.CancellationTokenSource = new CancellationTokenSource();
+
+                if (Port == 0)
+                {
+                    Port = GetAvailableTcpPort(ListenAddress);
+                }
+
+                var service = new PSHostGrpcTransportService(this, _serverInstance.CancellationTokenSource.Token);
+                var serverPort = new ServerPort(
+                    NormalizeListenAddress(ListenAddress),
+                    Port,
+                    ServerCredentials.Insecure);
+
+                _grpcServer = new Server
+                {
+                    Services = { PSHostGrpcTransport.BindService(service) },
+                    Ports = { serverPort }
+                };
+
+                _grpcServer.Start();
+                State = ServerState.Running;
+            }
+            catch (Exception ex)
+            {
+                State = ServerState.Failed;
+                LastError = ex;
+                throw;
+            }
+        }
+
+        public override void StopListenerAsync(bool force)
+        {
+            if (!TryBeginStopping())
+            {
+                return;
+            }
+
+            if (State != ServerState.Running && State != ServerState.Starting)
+            {
+                ResetStoppingFlag();
+                return;
+            }
+
+            State = ServerState.Stopping;
+
+            try
+            {
+                _serverInstance.CancellationTokenSource?.Cancel();
+
+                if (!force && ConnectionCount > 0)
+                {
+                    var drainStart = DateTime.UtcNow;
+                    var timeout = TimeSpan.FromSeconds(DrainTimeout);
+
+                    while (ConnectionCount > 0 && (DateTime.UtcNow - drainStart) < timeout)
+                    {
+                        Thread.Sleep(100);
+                    }
+                }
+
+                var connections = _serverInstance.ActiveConnections.Values.ToArray();
+                bool hadRemainingConnections = connections.Length > 0;
+                foreach (var connection in connections)
+                {
+                    if (!connection.ProcessId.HasValue)
+                    {
+                        continue;
+                    }
+
+                    try
+                    {
+                        var process = Process.GetProcessById(connection.ProcessId.Value);
+                        if (!process.HasExited)
+                        {
+                            process.Kill();
+                            process.WaitForExit(ProcessKillWaitTimeoutMs);
+                        }
+                    }
+                    catch { }
+                }
+
+                _serverInstance.ActiveConnections.Clear();
+
+                if (_grpcServer != null)
+                {
+                    if (force || hadRemainingConnections)
+                    {
+                        _grpcServer.KillAsync().Wait(ListenerThreadJoinTimeoutMs);
+                    }
+                    else
+                    {
+                        _grpcServer.ShutdownAsync().Wait(ListenerThreadJoinTimeoutMs);
+                    }
+                }
+
+                Unregister();
+                State = ServerState.Stopped;
+            }
+            catch (Exception ex)
+            {
+                Unregister();
+                State = ServerState.Failed;
+                LastError = ex;
+                throw;
+            }
+            finally
+            {
+                _serverInstance.CancellationTokenSource?.Dispose();
+                _serverInstance.CancellationTokenSource = null;
+                _grpcServer = null;
+                ResetStoppingFlag();
+            }
+        }
+
+        protected override void AcceptConnectionAsync()
+        {
+            throw new NotImplementedException("gRPC connections are accepted by the gRPC server runtime.");
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && _grpcServer != null)
+            {
+                try
+                {
+                    _grpcServer.KillAsync().Wait(ListenerThreadJoinTimeoutMs);
+                }
+                catch { }
+            }
+
+            base.Dispose(disposing);
+        }
+
+        private static bool IsLoopbackAddress(string listenAddress)
+        {
+            if (listenAddress.Equals("localhost", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
+            return IPAddress.TryParse(listenAddress, out var address) && IPAddress.IsLoopback(address);
+        }
+
+        private static string NormalizeListenAddress(string listenAddress)
+        {
+            if (listenAddress == "*" || listenAddress == "+")
+            {
+                return "0.0.0.0";
+            }
+
+            return listenAddress;
+        }
+
+        private static int GetAvailableTcpPort(string listenAddress)
+        {
+            IPAddress address;
+            if (listenAddress == "*" || listenAddress == "+" || listenAddress == "0.0.0.0")
+            {
+                address = IPAddress.Any;
+            }
+            else if (listenAddress.Equals("localhost", StringComparison.OrdinalIgnoreCase))
+            {
+                address = IPAddress.Loopback;
+            }
+            else if (!IPAddress.TryParse(listenAddress, out address!))
+            {
+                address = IPAddress.Loopback;
+            }
+
+            var listener = new TcpListener(address, 0);
+            listener.Start();
+            try
+            {
+                return ((IPEndPoint)listener.LocalEndpoint).Port;
+            }
+            finally
+            {
+                listener.Stop();
+            }
+        }
+
+        private sealed class PSHostGrpcTransportService : PSHostGrpcTransport.PSHostGrpcTransportBase
+        {
+            private readonly PSHostGrpcServer _owner;
+            private readonly CancellationToken _serverToken;
+
+            public PSHostGrpcTransportService(PSHostGrpcServer owner, CancellationToken serverToken)
+            {
+                _owner = owner;
+                _serverToken = serverToken;
+            }
+
+            public override async Task Connect(
+                IAsyncStreamReader<PSHostGrpcFrame> requestStream,
+                IServerStreamWriter<PSHostGrpcFrame> responseStream,
+                ServerCallContext context)
+            {
+                if (_owner.IsMaxConnectionsReached())
+                {
+                    throw new RpcException(new Status(StatusCode.ResourceExhausted, "Server at maximum capacity"));
+                }
+
+                var executable = PowerShellFinder.GetPowerShellPath();
+                if (executable == null || !File.Exists(executable))
+                {
+                    throw new RpcException(new Status(StatusCode.Internal, "The PowerShell executable path could not be found"));
+                }
+
+                var connectionId = Guid.NewGuid().ToString();
+                Process? process = null;
+
+                using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(_serverToken, context.CancellationToken);
+                using var writeLock = new SemaphoreSlim(1, 1);
+
+                try
+                {
+                    process = new Process();
+                    process.StartInfo.FileName = executable;
+                    process.StartInfo.Arguments = "-NoLogo -NoProfile -s";
+                    process.StartInfo.RedirectStandardInput = true;
+                    process.StartInfo.RedirectStandardOutput = true;
+                    process.StartInfo.RedirectStandardError = true;
+                    process.StartInfo.UseShellExecute = false;
+                    process.StartInfo.CreateNoWindow = true;
+
+                    process.Start();
+
+                    var clientAddress = context.Peer ?? "grpc-client";
+                    _owner.AddConnection(new ConnectionDetails(connectionId, clientAddress, process.Id));
+
+                    Task inputTask = ProxyGrpcToProcessAsync(requestStream, process.StandardInput.BaseStream, linkedCts.Token);
+                    Task outputTask = ProxyProcessToGrpcAsync(process.StandardOutput.BaseStream, responseStream, PSHostGrpcFrameKind.Output, writeLock, linkedCts.Token);
+                    Task errorTask = ProxyProcessToGrpcAsync(process.StandardError.BaseStream, responseStream, PSHostGrpcFrameKind.Error, writeLock, linkedCts.Token);
+
+                    await Task.WhenAny(inputTask, outputTask, errorTask).ConfigureAwait(false);
+                    linkedCts.Cancel();
+
+                    await ObserveTaskAsync(inputTask).ConfigureAwait(false);
+                    await ObserveTaskAsync(outputTask).ConfigureAwait(false);
+                    await ObserveTaskAsync(errorTask).ConfigureAwait(false);
+                }
+                finally
+                {
+                    _owner.RemoveConnection(connectionId);
+
+                    if (process != null)
+                    {
+                        try
+                        {
+                            if (!process.HasExited)
+                            {
+                                process.Kill();
+                                process.WaitForExit(ProcessKillWaitTimeoutMs);
+                            }
+                        }
+                        catch { }
+                        finally
+                        {
+                            process.Dispose();
+                        }
+                    }
+                }
+            }
+
+            private static async Task ProxyGrpcToProcessAsync(
+                IAsyncStreamReader<PSHostGrpcFrame> requestStream,
+                Stream destination,
+                CancellationToken cancellationToken)
+            {
+                while (await requestStream.MoveNext(cancellationToken).ConfigureAwait(false))
+                {
+                    var frame = requestStream.Current;
+                    if (frame.Kind == PSHostGrpcFrameKind.Close)
+                    {
+                        break;
+                    }
+
+                    if (frame.Kind != PSHostGrpcFrameKind.Input || frame.Payload.Length == 0)
+                    {
+                        continue;
+                    }
+
+                    byte[] buffer = frame.Payload.ToByteArray();
+                    await destination.WriteAsync(buffer, 0, buffer.Length, cancellationToken).ConfigureAwait(false);
+                    await destination.FlushAsync(cancellationToken).ConfigureAwait(false);
+                }
+            }
+
+            private static async Task ProxyProcessToGrpcAsync(
+                Stream source,
+                IServerStreamWriter<PSHostGrpcFrame> responseStream,
+                PSHostGrpcFrameKind kind,
+                SemaphoreSlim writeLock,
+                CancellationToken cancellationToken)
+            {
+                byte[] buffer = new byte[BufferSize];
+
+                while (true)
+                {
+                    int bytesRead = await source.ReadAsync(buffer, 0, buffer.Length, cancellationToken).ConfigureAwait(false);
+                    if (bytesRead <= 0)
+                    {
+                        break;
+                    }
+
+                    var frame = new PSHostGrpcFrame
+                    {
+                        Kind = kind,
+                        Payload = ByteString.CopyFrom(buffer, 0, bytesRead)
+                    };
+
+                    await writeLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+                    try
+                    {
+                        await responseStream.WriteAsync(frame).ConfigureAwait(false);
+                    }
+                    finally
+                    {
+                        writeLock.Release();
+                    }
+                }
+            }
+
+            private static async Task ObserveTaskAsync(Task task)
+            {
+                try
+                {
+                    await task.ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                }
+                catch (IOException)
+                {
+                }
+                catch (ObjectDisposedException)
+                {
+                }
+                catch (RpcException ex) when (ex.StatusCode == StatusCode.Cancelled)
+                {
+                }
+            }
+        }
+    }
+}

--- a/src/PSHostServerCommands.cs
+++ b/src/PSHostServerCommands.cs
@@ -150,10 +150,13 @@ namespace AwakeCoding.PSRemoting.PowerShell
             }
 
             // Check if another server is already listening on this port
-            var serverOnPort = PSHostServerBase.GetServerByPort(portValue);
-            if (serverOnPort != null)
+            if (portValue > 0)
             {
-                throw new InvalidOperationException($"Server '{serverOnPort.Name}' is already listening on port {portValue}");
+                var serverOnPort = PSHostServerBase.GetServerByPort(portValue);
+                if (serverOnPort != null)
+                {
+                    throw new InvalidOperationException($"Server '{serverOnPort.Name}' is already listening on port {portValue}");
+                }
             }
 
             return new PSHostTcpServer(

--- a/src/PSHostServerCommands.cs
+++ b/src/PSHostServerCommands.cs
@@ -8,7 +8,7 @@ namespace AwakeCoding.PSRemoting.PowerShell
     /// Start-PSHostServer cmdlet - Starts a PowerShell remoting server with specified transport
     /// </summary>
     [Cmdlet(VerbsLifecycle.Start, "PSHostServer")]
-    [OutputType(typeof(PSHostTcpServer), typeof(PSHostWebSocketServer), typeof(PSHostNamedPipeServer), typeof(PSHostWinRMServer))]
+    [OutputType(typeof(PSHostTcpServer), typeof(PSHostWebSocketServer), typeof(PSHostNamedPipeServer), typeof(PSHostWinRMServer), typeof(PSHostGrpcServer))]
     public sealed class StartPSHostServerCommand : PSCmdlet
     {
         // Common parameters
@@ -28,7 +28,7 @@ namespace AwakeCoding.PSRemoting.PowerShell
         [ValidateRange(0, int.MaxValue)]
         public int DrainTimeout { get; set; } = 30;
 
-        // TCP and WebSocket parameters
+        // TCP, WebSocket, and gRPC parameters
         [Parameter(Position = 1)]
         [ValidateRange(0, 65535)]
         public int? Port { get; set; }
@@ -44,6 +44,10 @@ namespace AwakeCoding.PSRemoting.PowerShell
 
         [Parameter()]
         public SwitchParameter UseSecureConnection { get; set; }
+
+        // gRPC-specific parameters
+        [Parameter()]
+        public SwitchParameter AllowUnencrypted { get; set; }
 
         // NamedPipe-specific parameters
         [Parameter(Position = 1)]
@@ -81,6 +85,10 @@ namespace AwakeCoding.PSRemoting.PowerShell
 
                     case PSHostTransportType.WinRM:
                         server = CreateWinRMServer();
+                        break;
+
+                    case PSHostTransportType.Grpc:
+                        server = CreateGrpcServer();
                         break;
 
                     default:
@@ -274,6 +282,39 @@ namespace AwakeCoding.PSRemoting.PowerShell
                 drainTimeout: DrainTimeout,
                 requiredCredential: Credential);
         }
+
+        private PSHostGrpcServer CreateGrpcServer()
+        {
+            if (!Port.HasValue)
+                throw new ArgumentException("Port parameter is required for gRPC transport");
+
+            int portValue = Port.Value;
+
+            if (string.IsNullOrWhiteSpace(Name))
+            {
+                Name = portValue == 0 ? $"PSHostGrpcServer{Guid.NewGuid().ToString("N").Substring(0, 8)}" : $"PSHostGrpcServer{portValue}";
+            }
+
+            var existingServer = PSHostServerBase.GetServer(Name);
+            if (existingServer != null)
+                throw new InvalidOperationException($"Server with name '{Name}' already exists");
+
+            if (portValue > 0)
+            {
+                var serverOnPort = PSHostServerBase.GetServerByPort(portValue);
+                if (serverOnPort != null)
+                    throw new InvalidOperationException($"Server '{serverOnPort.Name}' is already listening on port {portValue}");
+            }
+
+            return new PSHostGrpcServer(
+                name: Name,
+                port: portValue,
+                listenAddress: ListenAddress,
+                useSecureConnection: UseSecureConnection,
+                allowUnencrypted: AllowUnencrypted,
+                maxConnections: MaxConnections,
+                drainTimeout: DrainTimeout);
+        }
     }
 
     /// <summary>
@@ -374,7 +415,7 @@ namespace AwakeCoding.PSRemoting.PowerShell
     /// Get-PSHostServer cmdlet - Retrieves PowerShell remoting servers
     /// </summary>
     [Cmdlet(VerbsCommon.Get, "PSHostServer", DefaultParameterSetName = "All")]
-    [OutputType(typeof(PSHostTcpServer), typeof(PSHostWebSocketServer), typeof(PSHostNamedPipeServer), typeof(PSHostWinRMServer))]
+    [OutputType(typeof(PSHostTcpServer), typeof(PSHostWebSocketServer), typeof(PSHostNamedPipeServer), typeof(PSHostWinRMServer), typeof(PSHostGrpcServer))]
     public sealed class GetPSHostServerCommand : PSCmdlet
     {
         [Parameter(ParameterSetName = "ByName", Position = 0, Mandatory = true, ValueFromPipeline = true, ValueFromPipelineByPropertyName = true)]
@@ -453,6 +494,7 @@ namespace AwakeCoding.PSRemoting.PowerShell
                                 PSHostTransportType.WebSocket => allServers.OfType<PSHostWebSocketServer>(),
                                 PSHostTransportType.NamedPipe => allServers.OfType<PSHostNamedPipeServer>(),
                                 PSHostTransportType.WinRM => allServers.OfType<PSHostWinRMServer>(),
+                                PSHostTransportType.Grpc => allServers.OfType<PSHostGrpcServer>(),
                                 _ => allServers
                             };
                         }

--- a/src/PSHostSessionCommandBase.cs
+++ b/src/PSHostSessionCommandBase.cs
@@ -24,6 +24,7 @@ namespace AwakeCoding.PSRemoting.PowerShell
         protected const string SSHParameterSet = "SSH";
         protected const string WinRMComputerNameParameterSet = "WinRMComputerName";
         protected const string WinRMConnectionUriParameterSet = "WinRMConnectionUri";
+        protected const string GrpcParameterSet = "Grpc";
 
         protected const int DefaultOpenTimeoutMs = 30000;
         protected const int DefaultReadinessTimeoutMs = 5000;
@@ -223,6 +224,17 @@ namespace AwakeCoding.PSRemoting.PowerShell
 
         #endregion
 
+        #region gRPC Parameters
+
+        /// <summary>
+        /// gRPC endpoint URI (e.g., grpc://localhost:8080 or grpcs://localhost:8443)
+        /// </summary>
+        [Parameter(ParameterSetName = GrpcParameterSet, Mandatory = true, Position = 0)]
+        [ValidateNotNullOrEmpty()]
+        public Uri? GrpcUri { get; set; }
+
+        #endregion
+
         #region NamedPipe Parameters
 
         [Parameter(ParameterSetName = NamedPipeParameterSet, Mandatory = true)]
@@ -294,6 +306,11 @@ namespace AwakeCoding.PSRemoting.PowerShell
                 case WinRMConnectionUriParameterSet:
                     _connectionInfo = CreateWinRMConnectionInfo();
                     TransportName ??= "WinRM";
+                    break;
+
+                case GrpcParameterSet:
+                    _connectionInfo = CreateGrpcConnectionInfo();
+                    TransportName ??= "PSHostGrpc";
                     break;
 
                 case SubprocessParameterSet:
@@ -446,6 +463,30 @@ namespace AwakeCoding.PSRemoting.PowerShell
             };
 
             return connectionInfo;
+        }
+
+        private RunspaceConnectionInfo CreateGrpcConnectionInfo()
+        {
+            if (GrpcUri == null)
+            {
+                throw new ArgumentException("GrpcUri is required for gRPC connections");
+            }
+
+            if (!GrpcUri.Scheme.Equals("grpc", StringComparison.OrdinalIgnoreCase) &&
+                !GrpcUri.Scheme.Equals("grpcs", StringComparison.OrdinalIgnoreCase))
+            {
+                throw new ArgumentException($"Invalid gRPC URI scheme: {GrpcUri.Scheme}. Expected 'grpc' or 'grpcs'.");
+            }
+
+            if (GrpcUri.Port <= 0)
+            {
+                throw new ArgumentException("GrpcUri must include a port.");
+            }
+
+            return new PSHostGrpcClientInfo(GrpcUri)
+            {
+                OpenTimeout = OpenTimeout
+            };
         }
 
         private RunspaceConnectionInfo CreateSSHConnectionInfo()

--- a/src/PSHostTransportType.cs
+++ b/src/PSHostTransportType.cs
@@ -23,6 +23,11 @@ namespace AwakeCoding.PSRemoting.PowerShell
         /// <summary>
         /// WinRM (WSMan over HTTP/HTTPS) transport
         /// </summary>
-        WinRM
+        WinRM,
+
+        /// <summary>
+        /// gRPC transport
+        /// </summary>
+        Grpc
     }
 }

--- a/src/Protos/pshostgrpc.proto
+++ b/src/Protos/pshostgrpc.proto
@@ -1,0 +1,21 @@
+syntax = "proto3";
+
+option csharp_namespace = "AwakeCoding.PSRemoting.PowerShell.Grpc";
+
+package awakecoding.psremoting;
+
+service PSHostGrpcTransport {
+  rpc Connect(stream PSHostGrpcFrame) returns (stream PSHostGrpcFrame);
+}
+
+message PSHostGrpcFrame {
+  PSHostGrpcFrameKind kind = 1;
+  bytes payload = 2;
+}
+
+enum PSHostGrpcFrameKind {
+  Input = 0;
+  Output = 1;
+  Error = 2;
+  Close = 3;
+}

--- a/tests/AwakeCoding.PSRemoting.Tests.ps1
+++ b/tests/AwakeCoding.PSRemoting.Tests.ps1
@@ -199,6 +199,12 @@ Describe 'Module Manifest Tests' {
     It 'Requires PowerShell 7.2 or later' {
         $Manifest.PowerShellVersion | Should -BeGreaterOrEqual ([version]'7.2')
     }
+
+    It 'Includes gRPC dependencies in RequiredAssemblies' {
+        $Manifest.RequiredAssemblies | Should -Contain 'Google.Protobuf.dll'
+        $Manifest.RequiredAssemblies | Should -Contain 'Grpc.Core.Api.dll'
+        $Manifest.RequiredAssemblies | Should -Contain 'Grpc.Core.dll'
+    }
 }
 
 Describe 'New-PSHostSession Cmdlet Tests' {
@@ -213,6 +219,11 @@ Describe 'New-PSHostSession Cmdlet Tests' {
             $command.Parameters.ContainsKey('UseImplicitCredential') | Should -BeTrue
             $command.Parameters.ContainsKey('AuthenticationProvider') | Should -BeFalse
             $command.Parameters.ContainsKey('WinRMTransport') | Should -BeFalse
+        }
+
+        It 'Exposes gRPC URI parameter on New-PSHostSession and Enter-PSHostSession' {
+            (Get-Command New-PSHostSession).Parameters.ContainsKey('GrpcUri') | Should -BeTrue
+            (Get-Command Enter-PSHostSession).Parameters.ContainsKey('GrpcUri') | Should -BeTrue
         }
     }
 
@@ -995,6 +1006,72 @@ Describe 'Unified Server Cmdlet Tests' {
             }
         }
 
+        Context 'gRPC Server Tests' {
+            AfterEach {
+                Get-PSHostServer -TransportType Grpc -ErrorAction SilentlyContinue | Stop-PSHostServer -Force -ErrorAction SilentlyContinue
+            }
+
+            It 'Starts a gRPC server successfully' {
+                $server = Start-PSHostServer -TransportType Grpc -Port 0
+                try {
+                    $server | Should -Not -BeNullOrEmpty
+                    $server.State | Should -Be 'Running'
+                    $server.Port | Should -BeGreaterThan 0
+                    $server.ListenAddress | Should -Be '127.0.0.1'
+                    $server.GrpcUri | Should -Match "^grpc://127\.0\.0\.1:$($server.Port)$"
+                    $server.UseSecureConnection | Should -BeFalse
+                }
+                finally {
+                    Stop-PSHostServer -Server $server -Force
+                }
+            }
+
+            It 'Uses custom name when provided' {
+                $server = Start-PSHostServer -TransportType Grpc -Port 0 -Name 'GrpcNameTest'
+                try {
+                    $server.Name | Should -Be 'GrpcNameTest'
+                }
+                finally {
+                    Stop-PSHostServer -Server $server -Force
+                }
+            }
+
+            It 'Gets gRPC servers with TransportType filter' {
+                $server1 = Start-PSHostServer -TransportType Grpc -Port 0
+                $server2 = Start-PSHostServer -TransportType Grpc -Port 0
+                try {
+                    $servers = Get-PSHostServer -TransportType Grpc
+                    $servers | Should -HaveCount 2
+                }
+                finally {
+                    Stop-PSHostServer -Server $server1 -Force
+                    Stop-PSHostServer -Server $server2 -Force
+                }
+            }
+
+            It 'Stops gRPC server by port' {
+                $server = Start-PSHostServer -TransportType Grpc -Port 0
+                $port = $server.Port
+                Stop-PSHostServer -Port $port
+                $retrieved = Get-PSHostServer -Port $port -ErrorAction SilentlyContinue
+                $retrieved | Should -BeNullOrEmpty
+            }
+
+            It 'Throws error when starting gRPC server on duplicate port' {
+                $server1 = Start-PSHostServer -TransportType Grpc -Port 0 -Name 'GrpcServer1'
+                try {
+                    { Start-PSHostServer -TransportType Grpc -Port $server1.Port -Name 'GrpcServer2' -ErrorAction Stop } | Should -Throw -ExpectedMessage '*already*'
+                }
+                finally {
+                    Stop-PSHostServer -Server $server1 -Force
+                }
+            }
+
+            It 'Rejects non-loopback plaintext without explicit opt-in' {
+                { Start-PSHostServer -TransportType Grpc -Port 0 -ListenAddress '0.0.0.0' -ErrorAction Stop } | Should -Throw -ExpectedMessage '*Plaintext gRPC*'
+            }
+        }
+
         It 'Throws error if WinRM port is duplicate' {
             $server = Start-PSHostServer -TransportType WinRM -Port 19857
             try {
@@ -1024,9 +1101,10 @@ Describe 'Unified Server Cmdlet Tests' {
             $tcpServer = Start-PSHostServer -TransportType TCP -Port 0
             $wsServer = Start-PSHostServer -TransportType WebSocket -Port 8100
             $pipeServer = Start-PSHostServer -TransportType NamedPipe
+            $grpcServer = Start-PSHostServer -TransportType Grpc -Port 0
             try {
                 $allServers = Get-PSHostServer
-                $allServers | Should -HaveCount 3
+                $allServers | Should -HaveCount 4
                 
                 $tcpServers = Get-PSHostServer -TransportType TCP
                 $tcpServers | Should -HaveCount 1
@@ -1036,11 +1114,15 @@ Describe 'Unified Server Cmdlet Tests' {
                 
                 $pipeServers = Get-PSHostServer -TransportType NamedPipe
                 $pipeServers | Should -HaveCount 1
+
+                $grpcServers = Get-PSHostServer -TransportType Grpc
+                $grpcServers | Should -HaveCount 1
             }
             finally {
                 Stop-PSHostServer -Server $tcpServer -Force
                 Stop-PSHostServer -Server $wsServer -Force
                 Stop-PSHostServer -Server $pipeServer -Force
+                Stop-PSHostServer -Server $grpcServer -Force
             }
         }
     }
@@ -1205,6 +1287,77 @@ Describe 'End-to-End Client Transport Tests' {
         }
     }
 
+    Context 'gRPC Client Transport' {
+        BeforeAll {
+            $script:GrpcServer = Start-PSHostServer -TransportType Grpc -Port 0 -Name 'GrpcE2ETest'
+            $script:GrpcUri = [uri]$script:GrpcServer.GrpcUri
+        }
+
+        AfterAll {
+            Stop-PSHostServer -Server $script:GrpcServer -Force -ErrorAction SilentlyContinue
+        }
+
+        It 'Connects to gRPC server using URI' {
+            $session = New-PSHostSession -GrpcUri $script:GrpcUri -OpenTimeout 15000
+            try {
+                $session | Should -Not -BeNullOrEmpty
+                $session.State | Should -Be 'Opened'
+            }
+            finally {
+                Remove-PSHostSessionSafely -Session $session
+            }
+        }
+
+        It 'Executes commands over gRPC transport' {
+            $session = New-PSHostSession -GrpcUri $script:GrpcUri -OpenTimeout 15000
+            try {
+                $result = Invoke-Command -Session $session -ScriptBlock { 5 + 5 } -ErrorAction Stop
+                $result | Should -Be 10
+            }
+            finally {
+                Remove-PSHostSessionSafely -Session $session
+            }
+        }
+
+        It 'Retrieves PSVersionTable over gRPC' {
+            $session = New-PSHostSession -GrpcUri $script:GrpcUri -OpenTimeout 15000
+            try {
+                $version = Invoke-Command -Session $session -ScriptBlock { $PSVersionTable.PSVersion.Major } -ErrorAction Stop
+                $version | Should -BeGreaterOrEqual 7
+            }
+            finally {
+                Remove-PSHostSessionSafely -Session $session
+            }
+        }
+
+        It 'Supports multiple sequential gRPC connections' {
+            for ($i = 1; $i -le 3; $i++) {
+                $session = New-PSHostSession -GrpcUri $script:GrpcUri -OpenTimeout 15000
+                try {
+                    $result = Invoke-Command -Session $session -ScriptBlock { param($n) $n * 3 } -ArgumentList $i -ErrorAction Stop
+                    $result | Should -Be ($i * 3)
+                }
+                finally {
+                    Remove-PSHostSessionSafely -Session $session
+                }
+            }
+        }
+
+        It 'Supports two simultaneous gRPC sessions' {
+            $session1 = New-PSHostSession -GrpcUri $script:GrpcUri -OpenTimeout 15000
+            $session2 = New-PSHostSession -GrpcUri $script:GrpcUri -OpenTimeout 15000
+            try {
+                $session1.State | Should -Be 'Opened'
+                $session2.State | Should -Be 'Opened'
+                $session1.InstanceId | Should -Not -Be $session2.InstanceId
+            }
+            finally {
+                Remove-PSHostSessionSafely -Session $session1
+                Remove-PSHostSessionSafely -Session $session2
+            }
+        }
+    }
+
     Context 'Transport Error Handling' {
         It 'Throws timeout error when TCP server not listening' {
             { New-PSHostSession -HostName 'localhost' -Port 59999 -OpenTimeout 2000 -ErrorAction Stop } | Should -Throw
@@ -1216,6 +1369,14 @@ Describe 'End-to-End Client Transport Tests' {
 
         It 'Throws timeout error when named pipe does not exist' {
             { New-PSHostSession -PipeName 'NonExistentPipe12345' -OpenTimeout 2000 -ErrorAction Stop } | Should -Throw
+        }
+
+        It 'Throws error for invalid gRPC URI scheme' {
+            { New-PSHostSession -GrpcUri 'http://localhost:8080' -ErrorAction Stop } | Should -Throw -ExpectedMessage '*Invalid gRPC URI*'
+        }
+
+        It 'Throws timeout or connection error when gRPC server is not listening' {
+            { New-PSHostSession -GrpcUri 'grpc://localhost:59997' -OpenTimeout 2000 -ErrorAction Stop } | Should -Throw
         }
     }
 

--- a/tests/AwakeCoding.PSRemoting.Tests.ps1
+++ b/tests/AwakeCoding.PSRemoting.Tests.ps1
@@ -2,6 +2,11 @@ BeforeDiscovery {
     # Detect Docker availability during discovery for skip logic
     # Test-DockerAvailable checks for Linux container support
     $script:SSHTestingEnabled = $false
+    $script:GrpcTestingEnabled = -not (
+        [System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform([System.Runtime.InteropServices.OSPlatform]::OSX) -and
+        [System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture -eq [System.Runtime.InteropServices.Architecture]::Arm64
+    )
+
     $sshHelperPath = Join-Path $PSScriptRoot 'SSHTestHelper.psm1'
     if (Test-Path $sshHelperPath) {
         Import-Module $sshHelperPath -Force -ErrorAction SilentlyContinue
@@ -1006,7 +1011,7 @@ Describe 'Unified Server Cmdlet Tests' {
             }
         }
 
-        Context 'gRPC Server Tests' {
+        Context 'gRPC Server Tests' -Skip:(-not $script:GrpcTestingEnabled) {
             AfterEach {
                 Get-PSHostServer -TransportType Grpc -ErrorAction SilentlyContinue | Stop-PSHostServer -Force -ErrorAction SilentlyContinue
             }
@@ -1097,14 +1102,20 @@ Describe 'Unified Server Cmdlet Tests' {
 
     Context 'Mixed Transport Tests' {
 
-        It 'Can run all three transport types simultaneously' {
+        It 'Can run all supported transport types simultaneously' {
             $tcpServer = Start-PSHostServer -TransportType TCP -Port 0
             $wsServer = Start-PSHostServer -TransportType WebSocket -Port 8100
             $pipeServer = Start-PSHostServer -TransportType NamedPipe
-            $grpcServer = Start-PSHostServer -TransportType Grpc -Port 0
+            $grpcServer = $null
+
+            if ($script:GrpcTestingEnabled) {
+                $grpcServer = Start-PSHostServer -TransportType Grpc -Port 0
+            }
+
             try {
                 $allServers = Get-PSHostServer
-                $allServers | Should -HaveCount 4
+                $expectedServerCount = if ($script:GrpcTestingEnabled) { 4 } else { 3 }
+                $allServers | Should -HaveCount $expectedServerCount
                 
                 $tcpServers = Get-PSHostServer -TransportType TCP
                 $tcpServers | Should -HaveCount 1
@@ -1115,14 +1126,18 @@ Describe 'Unified Server Cmdlet Tests' {
                 $pipeServers = Get-PSHostServer -TransportType NamedPipe
                 $pipeServers | Should -HaveCount 1
 
-                $grpcServers = Get-PSHostServer -TransportType Grpc
-                $grpcServers | Should -HaveCount 1
+                if ($script:GrpcTestingEnabled) {
+                    $grpcServers = Get-PSHostServer -TransportType Grpc
+                    $grpcServers | Should -HaveCount 1
+                }
             }
             finally {
                 Stop-PSHostServer -Server $tcpServer -Force
                 Stop-PSHostServer -Server $wsServer -Force
                 Stop-PSHostServer -Server $pipeServer -Force
-                Stop-PSHostServer -Server $grpcServer -Force
+                if ($grpcServer) {
+                    Stop-PSHostServer -Server $grpcServer -Force
+                }
             }
         }
     }
@@ -1287,7 +1302,7 @@ Describe 'End-to-End Client Transport Tests' {
         }
     }
 
-    Context 'gRPC Client Transport' {
+    Context 'gRPC Client Transport' -Skip:(-not $script:GrpcTestingEnabled) {
         BeforeAll {
             $script:GrpcServer = Start-PSHostServer -TransportType Grpc -Port 0 -Name 'GrpcE2ETest'
             $script:GrpcUri = [uri]$script:GrpcServer.GrpcUri


### PR DESCRIPTION
## Summary
- add an internal protobuf/gRPC bidirectional stream transport for PSHost remoting
- wire gRPC into New/Enter-PSHostSession and Start/Get/Stop-PSHostServer
- package gRPC dependencies and add end-to-end Pester coverage

## Tests
- .\test.ps1